### PR TITLE
Support usage for stream test

### DIFF
--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -990,7 +990,6 @@ def init_parser(parser):
 def verify_arguments(environment, **kw):
     if not environment.parsed_options.stream and environment.parsed_options.stream_usage:
         print("WARNING: --stream-usage is set with --no-stream, ignoring")
-    # exit(1)
 
 @events.quitting.add_listener
 def _(environment, **kw):

--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -921,7 +921,7 @@ def init_parser(parser):
         "--stream-usage",
         action=argparse.BooleanOptionalAction,
         default=False,
-        help="Use stream_options.include_usage for OpenAI Compitable API",
+        help="Use stream_options.include_usage for OpenAI Compatible API",
     )
     parser.add_argument(
         "-k",


### PR DESCRIPTION
### Motivations
Currently, OpenAI and compatible APIs support usage information in stream response. With this option, we don't need to specify tokenizers to count tokens in stream chunks.
### Code changes
* Add `--stream-usage` to arguments
* Include `stream_options: {"include_usage": True}` to request body if `--stream-usage` is set
* Handle usage in stream chunks