### PR TITLE
Update logprobs handling

### DIFF
--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -290,7 +290,7 @@ class OpenAIProvider(BaseProvider):
         logprobs = choice.get("logprobs", None)
         return ChunkMetadata(
             text=text,
-            logprob_tokens=len(logprobs["tokens"]) if logprobs else None,
+            logprob_tokens=len(logprobs["content"]) if logprobs else None,
             usage_tokens=usage["completion_tokens"] if usage else None,
             prompt_usage_tokens=usage.get("prompt_tokens", None) if usage else None,
         )
@@ -923,7 +923,8 @@ def init_parser(parser):
     )
     parser.add_argument(
         "--logprobs",
-        type=int,
+        type=bool,
+        action=argparse.BooleanOptionalAction,
         default=None,
         help="Whether to ask for logprobs, it makes things slower for some providers but is necessary for token count in streaming (unless it's Fireworks API that returns usage in streaming mode)",
     )


### PR DESCRIPTION
Fix issues on logprobs request.

stream response is like
```
{
    "id": "f9873c36-67c2-445e-92a6-6646a0b31304",
    "object": "chat.completion.chunk",
    "created": 1723180270,
    "model": "model-name",
    "choices": [
        {
            "index": 0,
            "delta": {
                "content": "Hello!"
            },
            "finish_reason": null,
            "logprobs": {
                "content": [
                    {
                        "token": "Hello",
                        "logprob": -0.10208277,
                        "bytes": [
                            72,
                            101,
                            108,
                            108,
                            111
                        ],
                        "top_logprobs": [],
                        "token_id": 16230,
                        "text_offset": 0
                    },
                    {
                        "token": "!",
                        "logprob": -0.02145231,
                        "bytes": [
                            33
                        ],
                        "top_logprobs": [],
                        "token_id": 28808,
                        "text_offset": 5
                    }
                ]
            }
        }
    ],
    "usage": null
}
```

So need to count `logrpobs.content`