### PR TITLE
[FIR-1354] Add percentile latency

### DIFF
--- a/llm_bench/README.md
+++ b/llm_bench/README.md
@@ -102,7 +102,7 @@ locust -t 1min -u 100 -r 100 -p 512 -o 128 --stream --chat --qps 0.5 --summary-f
 Benchmark Fireworks public deployment deployment with 1 request only:
 
 ```bash
-locust -u 1 -H https://api.fireworks.ai/inference -p 128 -o 200 --api-key $FIREWORKS_API_KEY --model=accounts/fireworks/models/llama-v2-7b
+locust -u 1 -H https://api.fireworks.ai/inference -p 128 -o 200 --api-key $FIREWORKS_API_KEY --model=accounts/fireworks/models/llama-v3p1-8b-instruct
 ```
 
 Benchmark OpenAI deployment with 1 request only:

--- a/llm_bench/README.md
+++ b/llm_bench/README.md
@@ -102,7 +102,7 @@ locust -t 1min -u 100 -r 100 -p 512 -o 128 --stream --chat --qps 0.5 --summary-f
 Benchmark Fireworks public deployment deployment with 1 request only:
 
 ```bash
-locust -u 1 -H https://api.fireworks.ai/inference -p 128 -o 200 --api-key $FIREWORKS_API_KEY --model=accounts/fireworks/models/llama-v3p1-8b-instruct
+locust -u 1 -H https://api.fireworks.ai/inference -p 128 -o 200 --api-key $FIREWORKS_API_KEY --model=accounts/fireworks/models/llama-v3-8b
 ```
 
 Benchmark OpenAI deployment with 1 request only:

--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -1008,14 +1008,13 @@ def _(environment, **kw):
         entries["latency_per_token"] = ""
     entries["num_requests"] = total_latency.num_requests
     entries["qps"] = total_latency.total_rps
-    ttft_metrics = environment.stats.entries["time_to_first_token", "METRIC"]
-    entries["p50_ttft"] = ttft_metrics.get_response_time_percentile(0.50)
-    entries["p90_ttft"] = ttft_metrics.get_response_time_percentile(0.90)
-    entries["p99_ttft"] = ttft_metrics.get_response_time_percentile(0.99)
-    latency_metrics = environment.stats.entries["total_latency", "METRIC"]
-    entries["p50_latency"] = latency_metrics.get_response_time_percentile(0.50)
-    entries["p90_latency"] = latency_metrics.get_response_time_percentile(0.90)
-    entries["p99_latency"] = latency_metrics.get_response_time_percentile(0.99)
+    percentile_to_report = [50, 90, 99, 99.9]
+    percentile_metrics = ["time_to_first_token", "total_latency"]
+    for percentile_metrics in percentile_metrics:
+        metrics = environment.stats.entries[percentile_metrics, "METRIC"]
+        for percentile in percentile_to_report:
+            name = "P" + str(percentile) + "_" + percentile_metrics
+            entries[name] = metrics.get_response_time_percentile(percentile/100)
 
     pretty_name = lambda s: " ".join([w.capitalize() for w in s.split("_")])
     entries = {pretty_name(k): v for k, v in entries.items()}

--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -1010,10 +1010,10 @@ def _(environment, **kw):
     entries["qps"] = total_latency.total_rps
     percentile_to_report = [50, 90, 99, 99.9]
     percentile_metrics = ["time_to_first_token", "total_latency"]
-    for percentile_metrics in percentile_metrics:
-        metrics = environment.stats.entries[percentile_metrics, "METRIC"]
+    for percentile_metric in percentile_metrics:
+        metrics = environment.stats.entries[percentile_metric, "METRIC"]
         for percentile in percentile_to_report:
-            name = "P" + str(percentile) + "_" + percentile_metrics
+            name = "P" + str(percentile) + "_" + percentile_metric
             entries[name] = metrics.get_response_time_percentile(percentile/100)
 
     pretty_name = lambda s: " ".join([w.capitalize() for w in s.split("_")])

--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -1008,6 +1008,14 @@ def _(environment, **kw):
         entries["latency_per_token"] = ""
     entries["num_requests"] = total_latency.num_requests
     entries["qps"] = total_latency.total_rps
+    ttft_metrics = environment.stats.entries["time_to_first_token", "METRIC"]
+    entries["p50_ttft"] = ttft_metrics.get_response_time_percentile(0.50)
+    entries["p90_ttft"] = ttft_metrics.get_response_time_percentile(0.90)
+    entries["p99_ttft"] = ttft_metrics.get_response_time_percentile(0.99)
+    latency_metrics = environment.stats.entries["total_latency", "METRIC"]
+    entries["p50_latency"] = latency_metrics.get_response_time_percentile(0.50)
+    entries["p90_latency"] = latency_metrics.get_response_time_percentile(0.90)
+    entries["p99_latency"] = latency_metrics.get_response_time_percentile(0.99)
 
     pretty_name = lambda s: " ".join([w.capitalize() for w in s.split("_")])
     entries = {pretty_name(k): v for k, v in entries.items()}

--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -1013,7 +1013,7 @@ def _(environment, **kw):
     for percentile_metric in percentile_metrics:
         metrics = environment.stats.entries[percentile_metric, "METRIC"]
         for percentile in percentile_to_report:
-            name = "P" + str(percentile) + "_" + percentile_metric
+            name = f"P{percentile}_{percentile_metric}"
             entries[name] = metrics.get_response_time_percentile(percentile/100)
 
     pretty_name = lambda s: " ".join([w.capitalize() for w in s.split("_")])


### PR DESCRIPTION
Add latency percentile for TTFT and total latency.

Sample output:

Provider                 : fireworks
Model                    : accounts/fireworks/models/llama-v3p1-8b-instruct
Prompt Tokens            : 95.0
Generation Tokens        : 10
Stream                   : True
Temperature              : 1.0
Logprobs                 : None
Concurrency              : 1
Time To First Token      : 210.38031071094014
Latency Per Token        : 2.6568883196300557
Num Tokens               : 10.0
Total Latency            : 236.9491939072407
Num Requests             : 31
Qps                      : 3.9196468829393405
P50 Time To First Token  : 210.0
P90 Time To First Token  : 230.0
P99 Time To First Token  : 280.0
P99.9 Time To First Token: 280.0
P50 Total Latency        : 230.0
P90 Total Latency        : 250.0
P99 Total Latency        : 300.0
P99.9 Total Latency      : 300.0