### PR TITLE
[MUL-203] Fix prompt check when using images

### DIFF
--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -616,6 +616,7 @@ class LLMUser(HttpUser):
         else:
             assert (
                 self.environment.parsed_options.prompt_tokens >= PROMPT_SUFFIX_TOKENS
+                and self.environment.parsed_options.prompt_images_with_resolutions == []
             ), f"Minimal prompt length is {PROMPT_SUFFIX_TOKENS}"
             self.input = (
                 PROMPT_PREFIX_TOKEN

--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -615,8 +615,8 @@ class LLMUser(HttpUser):
             )[:prompt_chars]
         else:
             assert (
-                self.environment.parsed_options.prompt_tokens >= PROMPT_SUFFIX_TOKENS
-                and self.environment.parsed_options.prompt_images_with_resolutions == []
+                self.environment.parsed_options.prompt_images_with_resolutions != [] 
+                or self.environment.parsed_options.prompt_tokens >= PROMPT_SUFFIX_TOKENS
             ), f"Minimal prompt length is {PROMPT_SUFFIX_TOKENS}"
             self.input = (
                 PROMPT_PREFIX_TOKEN


### PR DESCRIPTION
- When using short text prompts with images, we hit this check

```
2025-05-10 18:54:08,924 INFO MainProcess:51:126460437931328 httptools_impl.py:476] INFO:     127.0.0.1:52806 - "GET /v1/models HTTP/1.1" 200 OK
** Provider fireworks using model accounts/models/models/phi-3-vision-8k-fp8 ***
Failed to initialize: AssertionError('Minimal prompt length is 35')
Traceback (most recent call last):
  File "/fw/benchmark/llm_bench/load_test.py", line 528, in on_start
    self._on_start()
  File "/fw/benchmark/llm_bench/load_test.py", line 618, in _on_start
    self.environment.parsed_options.prompt_tokens >= PROMPT_SUFFIX_TOKENS
AssertionError: Minimal prompt length is 35
```