### PR TITLE
Fix when prompt is less than suffix

### DIFF
--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -302,7 +302,6 @@ class FireworksProvider(OpenAIProvider):
         data = super().format_payload(prompt, max_tokens, images)
         data["min_tokens"] = max_tokens
         data["prompt_cache_max_len"] = self.parsed_options.prompt_cache_max_len
-        del data["model"]
         return data
 
 


### PR DESCRIPTION
When prompt_tokens is less than prompt_suffix no characters are randomized and prompt is larger than prompt_tokens

My use-case is when benchmarking ViTs - I want to only test the ViT, so ideally no text tokens but need a small amount of text tokens to avoid prefix caching