### PR TITLE
bug: check for logprobs is None

### DIFF
--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -284,7 +284,7 @@ class OpenAIProvider(BaseProvider):
             text = choice["text"]
 
         logprobs = choice.get("logprobs", None)
-        if "tokens" in logprobs:
+        if logprobs and "tokens" in logprobs:
             logprob_tokens = len(logprobs["tokens"])
         else:
             logprob_tokens = None


### PR DESCRIPTION
Requesting no logprobs results in null ptr error from when running load test. Fails when streaming