### PR TITLE
feat: implemented query limit

### DIFF
--- a/llm_bench/README.md
+++ b/llm_bench/README.md
@@ -65,6 +65,7 @@ Generation options:
 - `--chat`: specify to call chat API instead of raw completions
 - `--stream`: stream the result back. Enabling this gives "time to first token" and "time per token" metrics
 - (optional) `--logprobs`: corresponds to `logprobs` API parameter. For some providers, it's needed for output token counting in streaming mode.
+- `--num-queries`: stop sending requests after reaching specified number of queries.
 
 ### Writing results
 


### PR DESCRIPTION
This PR adds support for limiting the number of queries sent by locust for stopping requests after reaching specified number of queries. Changes include:
- adding argument `--num_queries`
- implementing a new function: `try_acquire_request()` and adding related flags
- updating `README.md`