### PR TITLE
Use real prompt

### DIFF
--- a/llm_bench/limericks.txt
+++ b/llm_bench/limericks.txt
@@ -1,0 +1,712 @@
+An elderly man called Keith,
+Mislaid his set of false teeth.
+They'd been laid on a chair,
+He'd forgot they were there,
+Sat down, and was bitten beneath.
+
+There once was a man from the sticks
+Who loved to compose limericks
+But he failed at his sport
+They were always too short...
+
+There once was a runner named Dwight
+Who could speed even faster than light.
+He set out one day
+In a relative way
+And returned on the previous night.
+
+There was a young lady named Alice
+Who was known to have peed in a chalice.
+‘Twas the common belief
+It was done for relief,
+And not out of protestant malice.
+
+A canner, exceedingly canny,
+One morning remarked to his granny,
+"A canner can can
+Anything that he can;
+But a canner can't can a can, can he?"
+
+At times I’m so mad that I’m hopping.
+My angriness sets my veins popping.
+I yell and I curse,
+With swear words diverse,
+But my wife does much worse: she goes shopping.
+
+A tutor who tooted a flute
+Tried to teach two young tooters to toot.
+Said the two to the tutor,
+“Is it harder to toot, or…
+To tutor two tooters to toot?”
+
+A crafty young bard named McMahon
+Whose poetry never would scan
+Once said, with a pause,
+“It’s probably because
+I’m always trying to cram as many additional syllables into the last line as I possibly can.”
+
+An elephant slept in his bunk,
+And in slumber his chest rose and sunk.
+But he snored - how he snored!
+All the other beasts roared,
+So his wife tied a knot in his trunk.
+
+There once was a man from Nantucket
+Who kept all his cash in a bucket
+His daughter, named Nan
+Ran away with a man
+And as for the bucket, Nantucket.
+
+I need a front door for my hall,
+The replacement I bought was too tall.
+So I hacked it and chopped it,
+And carefully lopped it,
+And now the dumb thing is too small.
+
+"There's a train at 4:04," said Miss Jenny.
+"Four tickets I'll take; have you any?"
+Said the man at the door,
+"Not four for 4:04,
+For four for 4:04 is too many."
+
+How to spell the potato has tried
+Many minds, sometimes mine, I’ll confide.
+Though it may have an eye,
+There’s no E – don’t ask why!
+Not until it’s been baked, boiled, or fried.
+
+I'd rather have Fingers than Toes,
+I'd rather have Ears than a Nose.
+And as for my Hair,
+I'm glad it's all there,
+I'll be awfully sad, when it goes.
+
+There was a faith-healer of Deal,
+Who said: "Although pain isn't real,
+If I sit on a pin
+And it punctures my skin,
+I dislike what I fancy I feel.'
+
+My dog is really quite hip,
+Except when he takes a cold dip.
+He looks like a fool,
+When he jumps in the pool,
+And reminds me of a sinking ship.
+
+I'm papering walls in the loo
+And quite frankly I haven't a clue;
+For the pattern's all wrong
+(Or the paper's too long)
+And I'm stuck to the toilet with glue.
+
+There once was an old man of Esser,
+Whose knowledge grew lesser and lesser,
+It at last grew so small
+He knew nothing at all
+And now he's a college professor.
+
+As 007 walked by
+He heard a wee spider say, "Hi."
+But shaken, he shot
+It right there on the spot
+As it tried to explain, "I'm a spi..."
+
+There was a young fellow of Crete
+Who was so exceedingly neat.
+When he got out of bed
+He stood on his head
+To make sure of not soiling his feet.
+
+An amoeba named Max and his brother
+Were sharing a drink with each other;
+In the midst of their quaffing,
+They split themselves laughing,
+And each of them now is a mother.
+
+A flea and a fly in a flue
+Were imprisoned, so what could they do?
+Said the fly, “Let us flee!”
+“Let us fly!” said the flea
+So they flew through a flaw in the flue.
+
+What happens when you retire?
+You really don't have to inquire -
+No job and no phone
+There's no place but home,
+And your checkbook's about to expire!
+
+The star violinist was bowing;
+The quarrelsome oarsmen were rowing.
+But how is the sage
+To discern from this page:
+Was it piglets, or seeds, that were sowing?
+
+An oyster from Kalamazoo
+Confessed he was feeling quite blue.
+For he said, “As a rule,
+When the weather turns cool,
+I invariably get in a stew.”
+
+A painter, who lived in Great Britain,
+Interrupted two girls with their knitting,
+He said, with a sigh,
+"That park bench, well I,
+Just painted it, right where you're sitting."
+
+I once had a gerbil named Bobby,
+Who had an unusual hobby.
+He chewed on a cord,
+and now - oh my lord,
+now all that's left is a blobby.
+
+My ambition, said old Mr. King,
+Is to live as a bird on the wing.
+Then he climbed up a steeple,
+Which scared all the people,
+So they caged him and taught him to sing.
+
+Is it me or the nature of money,
+That's odd and particularly funny.
+But when I have dough,
+It goes quickly, you know,
+And seeps out of my pockets like honey.
+
+A mouse in her room woke Miss Dowd
+She was frightened — it must be allowed.
+Soon a happy thought hit her —
+To scare off the critter,
+She sat up in bed and meowed.
+
+A nifty young flapper named Jane
+While walking was caught in the rain.
+She ran - almost flew,
+Her complexion did too,
+And she reached home exceedingly plain.
+
+There was an old person of Fratton
+Who would go to church with his hat on.
+'If I wake up,' he said,
+'With a hat on my head,
+I will know that it hasn't been sat on.'
+
+I told him, "Get out of my place
+You're an utter uncultured disgrace;
+You're a simpleton loon.
+Don't you know a good tune?"
+Then he walloped me square in the face.
+
+No woodsman would cut a wood, would he
+If woods would be woodless – nor should he.
+Yet no woodcutter would
+Cut a woody-wood wood
+If no woodsmen cut woody woods, would he?
+
+A forgetful old gasman named Dieter,
+Who went poking around his gas heater,
+Touched a leak with his light;
+He blew out of sight —
+And, as everyone who knows anything about poetry can tell you, he also ruined the meter.
+
+One Saturday morning at three
+A cheesemonger’s shop in Paree
+Collapsed to the ground
+With a thunderous sound
+Leaving only a pile of de brie.
+
+There was an old man of Peru,
+Who dreamt he was eating his shoe.
+He woke in the night,
+With a terrible fright,
+And found it was perfectly true.
+
+A crossword compiler named Moss
+Who found himself quite at a loss
+When asked, 'Why so blue?'
+Said, 'I haven't a clue
+I'm 2 Down to put 1 Across.'
+
+To compose a sonata today,
+Don't proceed in the old-fashioned way:
+With your toes on the keys,
+Bang the floor with your knees:
+"Oh how modern!" the critics will say.
+
+There was a young lady named Perkins,
+Who just simply doted on gherkins.
+In spite of advice,
+She ate so much spice,
+That she pickled her internal workins'.
+
+A certain young fellow named Bee-Bee
+Wished to wed a woman named Phoebe.
+"But," he said, "I must see
+What the clerical fee
+Be before Phoebe be Phoebe Bee-Bee."
+
+If you catch a chinchilla in Chile
+And cut off its beard, willy-nilly
+You can honestly say
+That you have just made
+A Chilean chinchilla's chin chilly.
+
+There once was a man from the city
+Stooped to pat what he thought was a kitty
+He gave it a pat
+But it wasn't a cat -
+They buried his clothes - what a pity!
+
+There was an old man of the Cape
+Who made himself garments of crepe.
+When asked, “Do they tear?”
+He replied, “Here and there,
+But they’re perfectly splendid for shape!”
+
+There was a young lady named Cager
+Who, as the result of a wager,
+Consented to fart
+The complete oboe part
+Of Mozart’s quartet in F major.
+
+The limerick packs laughs anatomical
+Into space that is quite economical.
+But the good ones I’ve seen
+So seldom are clean
+And the clean ones so seldom are comical.
+
+The incredible Wizard of Oz
+Retired from his business because
+Due to up-to-date science
+To most of his clients
+He wasn’t the Wizard he was.
+
+A wonderful bird is the pelican
+His bill holds more than his belican,
+He can take in his beak
+Enough food for a week
+But I’m damned if I see how the helican.
+
+There once was a lady named Ferris
+Whom nothing could ever embarrass.
+‘Til the bath salts one day,
+in the tub where she lay,
+turned out to be Plaster of Paris.
+
+There once was a girl named Irene
+Who lived on distilled kerosene
+But she started absorbing
+A new hydrocarbon
+And since then has never benzene.
+
+Is algebra fruitless endeavor?
+It seems they’ve been trying forever
+To find x, y, and z
+And it’s quite clear to me:
+If they’ve not found them yet then they’ll never.
+
+A rather disgruntled young Viking
+Found plunder was not to his liking
+When they yelled “All ashore,”
+He just threw down his oar
+And announced, “I’m not striking, I’m striking!”
+
+There once was a girl in the choir
+Whose voice rose up hoir and hoir,
+Till it reached such a height
+It went clear out of seight,
+And they found it next day in the spoir.
+
+There once was a fly on the wall,
+I wonder, why didn’t it fall?
+Because its feet stuck?
+Or was it just luck?
+Or does gravity miss things so small?
+
+There once was a farmer from Leeds,
+Who swallowed a packet of seeds.
+It soon came to pass,
+He was covered with grass,
+But has all the tomatoes he needs.
+
+There was once a great man in Japan
+Whose name on Tuesday began,
+It lasted through Sunday
+Till twilight on Monday
+And it sounded like stones in a can.
+
+Remember when nearly sixteen
+On your very first date as a teen
+At the movies? If yes,
+Then I bet you can't guess
+What was shown on the cinema screen.
+
+There was a young man from Dealing
+Who caught the bus for Ealing.
+It said on the door
+'Don't spit on the floor'
+So he jumped up and spat on the ceiling.
+
+There once was a man named Muvett
+Who lived in the city of Lovett
+But his car broke down
+Two miles out of town
+And Muvett had to shove it to Lovett!
+
+There once was a beautiful nurse
+Who carried an ugly old purse
+But she tripped on the door
+And fell on the floor
+And they both went away in the hearse.
+
+A bather whose clothing was strewed
+By breezes that left her quite nude,
+Saw a man come along
+And, unless I am wrong,
+You expect this last line to be lewd!
+
+An ambitious young fellow named Matt,
+Tried to parachute using his hat.
+Folks below looked so small,
+As he started to fall,
+Then got bigger and bigger and SPLAT!
+
+There was a young lady whose chin
+Resembled the point of a pin
+So she had it made sharp
+And purchased a harp
+And played several tunes with her chin.
+
+There was once a young girl who said: “Why
+Can’t I look in my ear with my eye?
+If I put my mind to it
+I’m sure I can do it.
+You never can tell till you try.”
+
+Limericks I cannot compose,
+With noxious smells in my nose.
+But this one was easy,
+I only felt queasy,
+Because I was sniffing my toes.
+
+There was an odd fellow named Gus,
+When traveling he made such a fuss.
+He was banned from the train,
+Not allowed on a plane,
+And now travels only by bus.
+
+There once was a man from Tibet,
+Who couldn't find a cigarette
+So he smoked all his socks,
+and got chicken-pox,
+and had to go to the vet.
+
+A newspaperman named Fling,
+Could make "copy" from any old thing.
+But the copy he wrote,
+Of a five-dollar note,
+Was so good he now wears so much bling.
+
+There is a young schoolboy named Mason,
+Whose mom cuts his hair with a basin.
+When he stands in one place,
+With a scarf round his face,
+It's a mystery which way he’s facing.
+
+There was a young schoolboy of Rye,
+Who was baked by mistake in a pie.
+To his mother’s disgust,
+He emerged through the crust,
+And exclaimed, with a yawn, where am I?
+
+A fellow jumped off a high wall,
+And had a most terrible fall.
+He went back to bed,
+With a bump on his head,
+That's why you don't jump off a wall.
+
+There was a young lady of Cork,
+Whose Pa made a fortune in pork.
+He bought for his daughter,
+A tutor who taught her,
+To balance green peas on her fork.
+
+There once was a Martian called Zed
+With antennae all over his head.
+He sent out a lot
+Di-di-dash-di-dot
+But nobody knew what he said.
+
+There once was a girl named Sam
+Who did not eat roast beef and ham
+She ate a green apple
+Then drank some Snapple
+Some say she eats like a lamb.
+
+A major, with wonderful force,
+Called out in Hyde Park for a horse.
+All the flowers looked round,
+But no horse could be found;
+So he just rhododendron, of course.
+
+A canny young fisher named Fisher
+Once fished from the edge of a fissure.
+A fish with a grin
+Pulled the fisherman in —
+Now they're fishing the fissure for Fisher.
+
+A cheerful old bear at the Zoo
+Could always find something to do.
+When it bored him, you know,
+To walk to and fro,
+He reversed it and walked fro and to.
+
+The bottle of perfume that Willie sent
+Was highly displeasing to Millicent;
+Her thanks were so cold
+They quarreled, I'm told,
+Through that silly scent Willie sent Millicent.
+
+I bought a new Hoover today,
+Plugged it in in the usual way,
+Switched it on - what a din;
+It sucked everything in,
+Now I'm homeless with no place to stay.
+
+There was a young lady named Hannah,
+Who slipped on a peel of banana.
+As she lay on her side,
+More stars she espied
+Than there are in the Star-Spangled Banner.
+
+My neighbor came over to say
+(Although not in a neighborly way)
+That he'd knock me around
+If I didn't curb the sound
+Of the classical music I play.
+
+There once was a man from Gorem
+Had a pair of tight pants and he wore 'em
+When he bowed with a grin
+A draft of air rushed in
+And he knew by the sound that he tore 'em!
+
+There was an Old Man in a tree,
+Who was horribly bored by a bee.
+When they said “Does it buzz?”
+He replied “Yes, it does!
+It’s a regular brute of a bee!”
+
+There was a young belle of old Natchez
+Whose garments were always in patchez.
+When comments arose
+On the state of her clothes,
+She replied, “When Ah itchez, Ah scratchez.”
+
+There was a young fellow from Belfast
+That I wanted so badly to tell fast
+Not to climb up the stair
+As the top step was air
+And that’s why the young fellow fell fast.
+
+There was an old girl of Genoa
+And I blush when I think that Iowa;
+She’s gone to her rest,
+It’s all for the best,
+Otherwise I would borrow Samoa.
+
+There was a dear lady of Eden,
+Who on apples was quite fond of feedin’;
+She gave one to Adam,
+Who said, “Thank you, Madam,”
+And then both skedaddled from Eden.
+
+I know an old owl named Boo,
+Every night he yelled Hoo,
+Once a kid walked by,
+And started to cry,
+And yelled I don't have a clue!
+
+I once fell in love with a blonde,
+But found that she wasn't so fond.
+Of my pet turtle named Odle,
+whom I'd taught how to Yodel,
+So she dumped him outside in the pond.
+
+A man and his lady-love, Min,
+Skated out where the ice was quite thin.
+Had a quarrel, no doubt,
+For I hear they fell out,
+What a blessing they didn't fall in!
+
+Said the man with a wink of his eye
+"But I love you" and then the reply
+From the girl, it was heard
+"You are truly absurd!
+I have only this moment walked by!"
+
+Leah is such a great swimmer.
+Leah is very much slimmer.
+She saw a big whale.
+It had a big tail.
+She put in a pot to simmer.
+
+Liam is afraid of a wolf.
+Tries to talk, but only goes woof.
+Liam bites meat too.
+The wolf only chews.
+Liam is such a silly goof.
+
+Jack is feeling scared of a fall.
+He is scared of playing basketball.
+He wants to play game.
+But his shot is lame.
+Gives it his all and the ball falls.
+
+Anne likes to skate on the cold ice.
+She thinks she has some skating spice.
+So, the big ice breaks.
+Then she starts to shake.
+She gets out and says, “That’s not nice.”
+
+Joe took a trip on a big boat.
+Joe had bought a really long rope.
+He pulled a big fish.
+The fish was a pitch.
+Joe rowed and rowed and rowed his boat.
+
+There was a nice girl named Jaray.
+She rhymed up and knew she could slay.
+Baddie knows she’s a 10.
+She talked it to win.
+She knows she could get some green pay.
+
+My brother saw one of his coats.
+Then my brother saw a cool boat.
+So, he grabbed a book.
+Then he saw a hook.
+Then my brother started to float.
+
+Peter is so scared of big rats.
+The rat is meaner than all cats.
+The rat bites and fights.
+He has a tall height.
+So, Peter becomes friends with rats.
+
+Hello, I’m the Earth, you love me.
+If you look closer you will see,
+I am in danger,
+Mars is a stranger.
+Mars is chasing me, please send help!
+
+Azuri is scared of the door.
+Her mom is honking the car horn.
+Her dad gets so mad.
+He says she so bad.
+Azuri plays with the front door.
+
+MJ is a great ball player.
+He is a fearless shot taker.
+When he dunks, he floats.
+That’s why he the G.O.A.T.
+He is the greatest shot maker.
+
+Ant-Man has no luck, he is stuck.
+He’s thinking man this really sucks.
+He starts to get mad.
+After he gets sad.
+Then he knew he had no good luck.
+
+Robert’s scared of a fight in the night.
+Woke with anime in his sight.
+Robert might bite you,
+Til’ your fingers blue.
+Robert saw a bad fight last night.
+
+Autumn is terrified of bees.
+The bees like to eat and smell feet.
+Bees love to waste time.
+And eat some green limes.
+The bees left to hide in the trees.
+
+There was an Old Man with a beard,
+Who said, 'It is just as I feared!
+Two Owls and a Hen,
+Four Larks and a Wren,
+Have all built their nests in my beard!'
+
+There was an Old Person of Ischia,
+Whose conduct grew friskier and friskier;
+He danced hornpipes and jigs,
+And ate thousands of figs,
+That lively Old Person of Ischia.
+
+There was an Old Man in a boat,
+Who said, 'I'm afloat, I'm afloat!'
+When they said, 'No! you ain't!'
+He was ready to faint,
+That unhappy Old Man in a boat.
+
+There was a Young Lady of Hull,
+Who was chased by a virulent bull;
+But she seized on a spade,
+And called out, 'Who's afraid?'
+Which distracted that virulent bull.
+
+There was an Old Person of Ems,
+Who casually fell in the Thames;
+And when he was found
+They said he was drowned,
+That unlucky Old Person of Ems.
+
+There was an Old Man who said, 'Hush!
+I perceive a young bird in this bush!'
+When they said, 'Is it small?'
+He replied, 'Not at all!
+It is four times as big as the bush!'
+
+There was a Young Lady of Russia,
+Who screamed so that no one could hush her;
+Her screams were extreme,
+No one heard such a scream,
+As was screamed by that lady of Russia.
+
+There was an Old Person of Ewell,
+Who chiefly subsisted on gruel;
+But to make it more nice
+He inserted some mice,
+Which refreshed that Old Person of Ewell.
+
+There was an old man in a tree,
+Whose whiskers were lovely to see;
+But the birds of the air,
+Pluck'd them perfectly bare,
+To make themselves nests on that tree.
+
+There is a Young Lady whose nose
+Continually prospers and grows;
+When it grew out of sight,
+She exclaimed in a fright,
+"Oh! Farewell to the end of my nose!"
+
+There was an Old Person of Dean,
+Who dined on one pea and one bean;
+For he said,
+"More than that would make me too fat,"
+That cautious Old Person of Dean.
+
+There was an Old Person of Dover,
+Who rushed through a field of blue Clover;
+But some very large bees,
+Stung his nose and his knees,
+So he very soon went back to Dover.
+
+There was an Old Man of Peru,
+Who watched his wife making a stew;
+But once by mistake,
+In a stove she did bake,
+That unfortunate Man of Peru.
+
+There was a Young Lady whose bonnet,
+Came untied when the birds sate upon it;
+But she said: 'I don't care!
+All the birds in the air
+Are welcome to sit on my bonnet!'


### PR DESCRIPTION
Randomly generated prompt and completions do not work for MoE models as it causes expert imbalance and skews perf measurements. Use real prompt instead.
The idea is to use a large-ish (~200) collection of limericks (5-line verses) and generate prompt by randomly picking them. Also prompt caching is controlled by a fixed prefix formed of limericks.
The prompt then asks to translate these limericks to Spanish and rewrite them 10 times with different styles (this works for output <= 10 * input - which is usually enough).
Tokenizer required for this mode.

Another option is to pass already generated dataset via --dataset '@file.jsonl'

Removed usage of locks - locust is running over greenlets in a single thread.

Updated README.md