### PR TITLE
remove unused param, breaking callsite

### DIFF
--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -386,7 +386,7 @@ class OpenAIProvider(BaseProvider):
 
         return data
 
-    def parse_output_json(self, data, prompt):
+    def parse_output_json(self, data):
         if self.parsed_options.embeddings:
             return ChunkMetadata(
                 text="",


### PR DESCRIPTION
This is an extraneous, unused argument, breaking current locust launch commands.