### PR TITLE
Start timer when all users have spawned

### DIFF
--- a/llm_bench/requirements.txt
+++ b/llm_bench/requirements.txt
@@ -1,3 +1,4 @@
 locust==2.18.1
 orjson==3.9.10
 pillow==10.0.0
+gevent==23.9.1


### PR DESCRIPTION
Ran into issue today where all my benchmarks were off because locust exited before all the users were spawned - so locust never got to reset the stats and run the full benchmark.

I don't think there's any reason not to do this - recording stats before all users have spawned doesn't seem that useful.