### PR TITLE
Fix resolve_max_seq_len for VLMs with nested text_config

### DIFF
--- a/llm_bench/gen_load_test.py
+++ b/llm_bench/gen_load_test.py
@@ -56,6 +56,9 @@ def get_profile_batch_sizes(max_batch_size: int) -> list[int]:
 
 def resolve_max_seq_len(tokenizer_path: str) -> int:
     config = transformers.AutoConfig.from_pretrained(tokenizer_path, trust_remote_code=True)
+    # For VLMs (e.g. Kimi K2.5, LLaMA Vision), max_position_embeddings lives
+    # under text_config rather than at the top level.
+    config = config.get_text_config()
     for name in (
         "max_position_embeddings",
         "model_max_length",

--- a/llm_bench/prefill_load_test.py
+++ b/llm_bench/prefill_load_test.py
@@ -40,6 +40,9 @@ def _load_auto_tokenizer(tokenizer_path: str) -> transformers.PreTrainedTokenize
 
 def resolve_max_seq_len(tokenizer_path: str) -> int:
     config = transformers.AutoConfig.from_pretrained(tokenizer_path, trust_remote_code=True)
+    # For VLMs (e.g. Kimi K2.5, LLaMA Vision), max_position_embeddings lives
+    # under text_config rather than at the top level.
+    config = config.get_text_config()
     for name in (
         "max_position_embeddings",
         "model_max_length",


### PR DESCRIPTION
## Summary

- Fixes `resolve_max_seq_len()` in both `gen_load_test.py` and `prefill_load_test.py` to handle vision-language models (VLMs) where `max_position_embeddings` is nested under `text_config` rather than at the top level of the HF config.
- Adds a call to `config.get_text_config()` after loading the HF config. This is a no-op for pure text models (returns `self`) and returns the text sub-config for VLMs.

## Motivation

VLMs like [Kimi K2.5](https://huggingface.co/moonshotai/Kimi-K2.5/blob/main/config.json) structure their `config.json` with a top-level wrapper containing `text_config` and `vision_config`. The `max_position_embeddings` field (262144 for Kimi K2.5) lives inside `text_config`, not at the top level. Without this fix, `resolve_max_seq_len()` fails to find the field and raises a `ValueError`.

Other VLMs with the same nested structure include LLaMA Vision, LLaMA 4, Qwen2 VL, Qwen3 VL, and Qwen3.5. The Fireworks engine itself handles this per-model in each `convert_hf_config()` method (e.g. `hf_config.text_config.max_position_embeddings` or `hf_config.get_text_config().max_position_embeddings`).

## Test plan

- [ ] Run `gen_load_test.py --tokenizer moonshotai/Kimi-K2.5` and verify it resolves `max_seq_len=262144` instead of raising `ValueError`
- [ ] Run `gen_load_test.py` with a pure text model (e.g. DeepSeek V3) and verify behavior is unchanged

Made with [Cursor](https://cursor.com)