### PR TITLE
Remove --prompt-cache-max-pct flag; use --prompt-cache-max-len only

### DIFF
--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -832,8 +832,8 @@ class FireworksProvider(OpenAIProvider):
             return data
         # Enable perf_metrics_in_response to get speculation stats in streaming responses
         data["perf_metrics_in_response"] = True
-        if self.parsed_options.prompt_cache_max_pct is not None:
-            data["prompt_cache_max_pct"] = int(self.parsed_options.prompt_cache_max_pct)
+        if self.parsed_options.prompt_cache_max_len:
+            data["prompt_cache_max_len"] = self.parsed_options.prompt_cache_max_len
         if self._acceptance_probs_override is not None:
             data["acceptance_probs_override"] = self._acceptance_probs_override
         if self._forced_generation_pool is not None:
@@ -1703,14 +1703,6 @@ def init_parser(parser):
         type=int,
         default=0,
         help="Maximum length of the prompt cache to use. Defaults to 0 (no caching).",
-    )
-    parser.add_argument(
-        "--prompt-cache-max-pct",
-        env_var="PROMPT_CACHE_MAX_PCT",
-        type=float,
-        default=None,
-        help="(Fireworks only) Maximum percentage of prompt tokens to use for prompt cache (0-100). "
-        "Passed as prompt_cache_max_pct in the API request. Ignored for other providers.",
     )
     parser.add_argument(
         "--acceptance-probs-override",


### PR DESCRIPTION
### Description
prompt-cache-max-pct did not drive dataset prefix engineering (common_tokens was always 0 when only pct was set), so cache hits were never guaranteed. prompt-cache-max-len drives both prefix engineering and the server hint, making it the correct single interface for prompt cache control.

Also adds prompt_cache_max_len to the Fireworks format_payload so the server hint is forwarded when the flag is set (previously only used for dataset prep).

## Testing

- [x] Verify `load_test.py` no longer accepts `--prompt-cache-max-pct` (companion benchmark PR)
```
(base) annichen@Annis-MacBook-Pro benchmark % locust -f llm_bench/load_test.py \
          --headless \
          --users 1 \
          --spawn-rate 1 \
          --run-time 15s \
          --host https://api.fireworks.ai/inference \
          --model accounts/fireworks/models/llama-v3p1-8b-instruct \
          --api-key "$FIREWORKS_API_KEY" \
          --tokenizer Qwen/Qwen2.5-7B-Instruct \
          --prompt-tokens 500 \
          --max-tokens 10 \
          --prompt-cache-max-pct 30 \ 
          --chat
PyTorch was not found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.
locust: error: unrecognized arguments: --prompt-cache-max-pct
Did you mean '--prompt-cache-max-len'?
```
- [x] Verify `--prompt-cache-max-len 59500` with `--prompt-tokens 70000` produces expected cache prefix behavior in load tests

<img width="1230" height="531" alt="image" src="https://github.com/user-attachments/assets/847193b8-9350-4edc-b0b9-d1ce3dc3eddf" />

```
data: {'model': 'accounts/fireworks/models/llama-v3p1-8b-instruct', 'max_tokens': 10, 'stream': True, 'temperature': 1.0, 'n': 1, 'stream_options': {'include_usage': True}, 'messages': [{'role': 'user', 'content': 'An elderly man called Keith,\nMislaid his set of false teeth.\nThey\'d been laid on a chair,\nHe\'d forgot they were there,\nSat down, and was bitten beneath.\n\nThere once was a man from the sticks\nWho loved to compose limericks\nBut he failed at his sport\nThey were always too short...\n\nThere once was a runner named Dwight\nWho could speed even faster than light.\nHe set out one day\nIn a relative way\nAnd returned on the previous night.\n\nThere was a young lady named Alice\nWho was known to have peed in a chalice.\n‘Twas the common belief\nIt was done for relief,\nAnd not out of protestant malice.\n\nA canner, exceedingly canny,\nOne morning remarked to his granny,\n"A canner can can\nAnything that he can;\nBut a canner can\'t can a can, can he?"\n\nAt times I’m so mad that I’m hopping.\nMy angriness sets my veins popping.\nI yell and I curse,\nWith swear words diverse,\nBut my wife does much worse: she goes shopping.\n\nA tutor who tooted a flute\nTried to teach two young tooters to toot.\nSaid the two to the tutor,\n“Is it harder to toot, or…\nTo tutor two tooters to toot?”\n\nA crafty young bard named McMahon\nWhose poetry never would scan\nOnce said, with a pause,\n“It’s probably because\nI’m always trying to cram as many additional syllables into the last line as I possibly can.”\n\nThere is a Young Lady whose nose\nContinually prospers and grows;\nWhen it grew out of sight,\nShe exclaimed in a fright,\n"Oh! Farewell to the end of my nose!"\n\nA canner, exceedingly canny,\nOne morning remarked to his granny,\n"A canner can can\nAnything that he can;\nBut a canner can\'t can a can, can he?"\n\nMy dog is really quite hip,\nExcept when he takes a cold dip.\nHe looks like a fool,\nWhen he jumps in the pool,\nAnd reminds me of a sinking ship.\n\nI\'m papering walls in the loo\nAnd quite frankly I haven\'t a clue;\nFor the pattern\'s all wrong\n(Or the paper\'s too long)\nAnd I\'m stuck to the toilet with glue.\n\nA bather whose clothing was strewed\nBy breezes that left her quite nude,\nSaw a man come along\nAnd, unless I am wrong,\nYou expect this last line to be lewd!\n\n\n\nTranslate the limericks above to Spanish.'}], 'perf_metrics_in_response': True, 'prompt_cache_max_len': 300}
```