### PR TITLE
llm_bench: unify requirements.txt; ignore .venv directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 llm_bench/results/
 .env
 env/
+.venv*/

--- a/llm_bench/requirements.txt
+++ b/llm_bench/requirements.txt
@@ -1,8 +1,11 @@
-locust
-tabulate
-orjson
-pillow
+locust==2.18.1
+orjson==3.9.10
+pillow==10.0.0
+
 gevent
-transformers
 locust-plugins
+pandas
+python-dotenv
+tabulate
 tiktoken
+transformers


### PR DESCRIPTION
## Summary

- Unify `llm_bench/requirements.txt` with Customers CI pins for `locust`, `orjson`, and `pillow`; add `pandas` and `python-dotenv`; keep `gevent`, `locust-plugins`, `tabulate`, `tiktoken`, `transformers`.
- Add `.venv*/` to `benchmark/.gitignore` so local virtual environments are not committed.

Part of the benchmark / Customers `llm_bench` consolidation (deps-only PR).

## How tested

```bash
cd llm_bench
python3 -m venv .venv
source .venv/bin/activate
pip install -U pip
pip install -r requirements.txt

locust -f load_test.py --headless \
  -u 2 -r 1 -t 2m \
  --host https://api.fireworks.ai/inference \
  -k "$FIREWORKS_API_KEY" \
  --provider fireworks \
  -m "accounts/fireworks/models/llama-v3p3-70b-instruct" \
  --tokenizer "<path-to-local-qwen-tokenizer>"
```
<img width="954" height="771" alt="image" src="https://github.com/user-attachments/assets/17dddbc0-032f-40dc-be0b-f5afb71eb8af" />

Load test ran successfully. 

Made with [Cursor](https://cursor.com)