### PR TITLE
llm_bench: emit num_tokens alias; fix TGI non-streaming chunk routing

### DIFF
--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -737,6 +737,18 @@ class OpenAIProvider(BaseProvider):
             )
         usage = data.get("usage", None)
 
+        # Trailing usage-only SSE chunk (choices absent or empty) — return metadata
+        # without trying to extract text from a missing choice.
+        if len(data.get("choices", [])) == 0:
+            prompt_tokens_details = (usage or {}).get("prompt_tokens_details") or {}
+            return ChunkMetadata(
+                text="",
+                logprob_tokens=None,
+                completion_tokens=usage.get("completion_tokens") if usage else None,
+                prompt_tokens=usage.get("prompt_tokens") if usage else None,
+                cached_tokens=prompt_tokens_details.get("cached_tokens"),
+            )
+
         assert len(data["choices"]) == 1, f"Too many choices {len(data['choices'])}"
         choice = data["choices"][0]
         if self.parsed_options.chat:
@@ -1246,7 +1258,6 @@ class LLMUser(HttpUser):
             catch_response=True,
         ) as response:
             combined_text = ""
-            done_empty_chunk = False
             done = False
             completion_tokens = None
             total_logprob_tokens = None
@@ -1290,24 +1301,10 @@ class LLMUser(HttpUser):
                         if chunk.strip() == b"[DONE]":
                             done = True
                             continue
-                    if done_empty_chunk:
-                        print(f"WARNING: Received more chunks after the trailing last chunk: {chunk}")
                     data = orjson.loads(chunk)
                     # Capture perf_metrics if present (usually in final usage chunk)
                     if data.get("perf_metrics"):
                         perf_metrics = data["perf_metrics"]
-                    if not data.get("choices"):
-                        usage = data.get("usage")
-                        if usage and usage.get("completion_tokens"):
-                            completion_tokens = usage["completion_tokens"]
-                        if usage and usage.get("prompt_tokens"):
-                            prompt_tokens = usage["prompt_tokens"]
-                        if usage:
-                            prompt_tokens_details = usage.get("prompt_tokens_details") or {}
-                            if prompt_tokens_details.get("cached_tokens") is not None:
-                                cached_tokens = prompt_tokens_details["cached_tokens"]
-                        done_empty_chunk = True
-                        continue
                     out = self.provider_formatter.parse_output_json(data)
                     if out.completion_tokens:
                         completion_tokens = out.completion_tokens
@@ -1386,6 +1383,7 @@ class LLMUser(HttpUser):
                 if num_tokens != max_tokens:
                     print(f"WARNING: wrong number of tokens: {num_tokens}, expected {max_tokens}")
                 add_custom_metric("completion_tokens", num_tokens)
+                add_custom_metric("num_tokens", num_tokens)
                 add_custom_metric("latency_per_token", dur_generation / num_tokens * 1000, num_tokens)
                 add_custom_metric(
                     "overall_latency_per_token",
@@ -1811,6 +1809,7 @@ def _(environment, **kw):
             "overall_latency_per_token",
             "total_latency",
             "completion_tokens",
+            "num_tokens",
             "prompt_tokens",
         ]:
             entries[metric_name] = environment.stats.entries[(metric_name, "METRIC")].avg_response_time


### PR DESCRIPTION
## Summary

- **Emit `num_tokens` alongside `completion_tokens`** on every request. Both names carry the same value; `completion_tokens` is consumed by the shape GHA / load-test-agent, `num_tokens` is expected by Customers-side downstream parsers. Adds `num_tokens` to the quitting summary CSV output as well.

- **Fix TGI non-streaming chunk routing.** The old `_do_generate_text` loop contained a guard `if not data.get("choices"): ... continue` designed for OpenAI's trailing usage-only SSE chunk. TGI's non-streaming response body (`{"generated_text": "..."}`) also has no `choices` key, so it was silently discarded — every TGI non-streaming request failed with "empty response received". Fix: move the no-choices case into `OpenAIProvider.parse_output_json` (returning `ChunkMetadata(text="", ...)` with usage fields), and remove the guard from the loop entirely. Every chunk now routes unconditionally to `parse_output_json`, matching Customers' architecture.

## Test plan

- [x] Run `load_test.py` against a Fireworks endpoint with streaming — confirm `completion_tokens` and `num_tokens` both appear in the Locust CSV output with equal values. 
```
locust -f load_test.py --headless \
  -u 2 -r 1 -t 30s \
  --host https://api.fireworks.ai/inference \
  --api-key "$FIREWORKS_API_KEY" \
  --provider fireworks \
  -m "accounts/fireworks/models/llama-v3p3-70b-instruct" \
  --tokenizer hf-qwen35-9b \
  --max-tokens 50 \
  --prompt-tokens 100 \
  --summary-file /Users/annichen/Downloads/test_result.csv \
  --csv /Users/annichen/Downloads/
```
<img width="505" height="70" alt="image" src="https://github.com/user-attachments/assets/294f0abb-8f1b-4648-968a-bc0b3887451c" />

- [x] Run `load_test.py` against a Fireworks endpoint — confirm summary CSV contains `num_tokens` column
<img width="296" height="126" alt="image" src="https://github.com/user-attachments/assets/af59e093-5fa6-4068-8e9c-c32c45912bb7" />

- [x] Run `load_test.py` with `--provider tgi` in non-streaming mode — confirm requests no longer fail with "empty response received"
Mocked a TGI server locally. 
See error with old code. 
<img width="1189" height="103" alt="image" src="https://github.com/user-attachments/assets/1518e7c4-ce0c-45bf-af6d-4aa99a4c93c6" />

```
locust -f load_test.py --headless \
  -u 1 -r 1 -t 15s \
  --host http://127.0.0.1:8999 \
  --provider tgi \
  --no-chat \
  --no-stream \
  --max-tokens 10 \
  --prompt-tokens 20 \
  --csv /tmp/tgi_run
```

No longer see the error after the fix. 

Made with [Cursor](https://cursor.com)