### PR TITLE
llm_bench: add TritonInferProvider, TritonGenerateProvider, anyscale

### DIFF
--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -737,6 +737,18 @@ class OpenAIProvider(BaseProvider):
             )
         usage = data.get("usage", None)
 
+        # Trailing usage-only SSE chunk (choices absent or empty) — return metadata
+        # without trying to extract text from a missing choice.
+        if len(data.get("choices", [])) == 0:
+            prompt_tokens_details = (usage or {}).get("prompt_tokens_details") or {}
+            return ChunkMetadata(
+                text="",
+                logprob_tokens=None,
+                completion_tokens=usage.get("completion_tokens") if usage else None,
+                prompt_tokens=usage.get("prompt_tokens") if usage else None,
+                cached_tokens=prompt_tokens_details.get("cached_tokens"),
+            )
+
         assert len(data["choices"]) == 1, f"Too many choices {len(data['choices'])}"
         choice = data["choices"][0]
         if self.parsed_options.chat:
@@ -1246,7 +1258,6 @@ class LLMUser(HttpUser):
             catch_response=True,
         ) as response:
             combined_text = ""
-            done_empty_chunk = False
             done = False
             completion_tokens = None
             total_logprob_tokens = None
@@ -1290,24 +1301,10 @@ class LLMUser(HttpUser):
                         if chunk.strip() == b"[DONE]":
                             done = True
                             continue
-                    if done_empty_chunk:
-                        print(f"WARNING: Received more chunks after the trailing last chunk: {chunk}")
                     data = orjson.loads(chunk)
                     # Capture perf_metrics if present (usually in final usage chunk)
                     if data.get("perf_metrics"):
                         perf_metrics = data["perf_metrics"]
-                    if not data.get("choices"):
-                        usage = data.get("usage")
-                        if usage and usage.get("completion_tokens"):
-                            completion_tokens = usage["completion_tokens"]
-                        if usage and usage.get("prompt_tokens"):
-                            prompt_tokens = usage["prompt_tokens"]
-                        if usage:
-                            prompt_tokens_details = usage.get("prompt_tokens_details") or {}
-                            if prompt_tokens_details.get("cached_tokens") is not None:
-                                cached_tokens = prompt_tokens_details["cached_tokens"]
-                        done_empty_chunk = True
-                        continue
                     out = self.provider_formatter.parse_output_json(data)
                     if out.completion_tokens:
                         completion_tokens = out.completion_tokens
@@ -1386,6 +1383,7 @@ class LLMUser(HttpUser):
                 if num_tokens != max_tokens:
                     print(f"WARNING: wrong number of tokens: {num_tokens}, expected {max_tokens}")
                 add_custom_metric("completion_tokens", num_tokens)
+                add_custom_metric("num_tokens", num_tokens)
                 add_custom_metric("latency_per_token", dur_generation / num_tokens * 1000, num_tokens)
                 add_custom_metric(
                     "overall_latency_per_token",
@@ -1811,6 +1809,7 @@ def _(environment, **kw):
             "overall_latency_per_token",
             "total_latency",
             "completion_tokens",
+            "num_tokens",
             "prompt_tokens",
         ]:
             entries[metric_name] = environment.stats.entries[(metric_name, "METRIC")].avg_response_time

--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -923,6 +923,101 @@ class TogetherProvider(OpenAIProvider):
         return super().parse_output_json(data)
 
 
+class TritonInferProvider(BaseProvider):
+    """Triton Inference Server — /v2/models/{model}/infer endpoint (non-streaming only)."""
+
+    DEFAULT_MODEL_NAME = "ensemble"
+
+    def get_url(self):
+        assert not self.parsed_options.chat, "Chat is not supported"
+        assert not self.parsed_options.stream, "Streaming is not supported"
+        assert self.parsed_options.n == 1, "n > 1 is not supported"
+        return f"/v2/models/{self.model}/infer"
+
+    def format_payload(self, prompt, max_tokens, images):
+        assert isinstance(prompt, str), "prompt must be a string"
+        assert images is None, "images are not supported"
+        assert self.parsed_options.logprobs is None, "logprobs are not supported"
+        # Store prompt so parse_output_json can strip the echoed prefix from the response.
+        self._last_prompt = prompt
+        return {
+            "inputs": [
+                {"name": "text_input", "datatype": "BYTES", "shape": [1, 1], "data": [[prompt]]},
+                {"name": "max_tokens", "datatype": "UINT32", "shape": [1, 1], "data": [[max_tokens]]},
+                {"name": "bad_words", "datatype": "BYTES", "shape": [1, 1], "data": [[""]]},
+                {"name": "stop_words", "datatype": "BYTES", "shape": [1, 1], "data": [[""]]},
+                {"name": "temperature", "datatype": "FP32", "shape": [1, 1], "data": [[self.parsed_options.temperature]]},
+            ]
+        }
+
+    def parse_output_json(self, data):
+        prompt = getattr(self, "_last_prompt", "")
+        for output in data["outputs"]:
+            if output["name"] == "text_output":
+                assert output["datatype"] == "BYTES"
+                assert output["shape"] == [1]
+                text = output["data"][0]
+                # Triton echoes the prompt in the response; strip it.
+                text = text.removeprefix("<s> ")
+                if text.startswith(prompt):
+                    text = text[len(prompt):].removeprefix(" ")
+                else:
+                    print("WARNING: prompt not found in the output")
+                return ChunkMetadata(
+                    text=text,
+                    logprob_tokens=None,
+                    completion_tokens=None,
+                    prompt_tokens=None,
+                    cached_tokens=None,
+                )
+        raise ValueError("text_output not found in the response")
+
+
+class TritonGenerateProvider(BaseProvider):
+    """Triton Inference Server — /v2/models/{model}/generate[_stream] endpoint."""
+
+    DEFAULT_MODEL_NAME = "ensemble"
+
+    def get_url(self):
+        assert not self.parsed_options.chat, "Chat is not supported"
+        assert self.parsed_options.n == 1, "n > 1 is not supported"
+        stream_suffix = "_stream" if self.parsed_options.stream else ""
+        return f"/v2/models/{self.model}/generate{stream_suffix}"
+
+    def format_payload(self, prompt, max_tokens, images):
+        assert isinstance(prompt, str), "prompt must be a string"
+        assert images is None, "images are not supported"
+        assert self.parsed_options.logprobs is None, "logprobs are not supported"
+        # Store prompt so parse_output_json can strip the echoed prefix in non-streaming mode.
+        self._last_prompt = prompt
+        return {
+            "text_input": prompt,
+            "max_tokens": max_tokens,
+            "stream": self.parsed_options.stream,
+            "temperature": self.parsed_options.temperature,
+            "bad_words": "",
+            "stop_words": "",
+        }
+
+    def parse_output_json(self, data):
+        text = data["text_output"]
+        if not self.parsed_options.stream:
+            # Non-streaming: Triton echoes the prompt in the response; strip it.
+            prompt = getattr(self, "_last_prompt", "")
+            text = text.removeprefix("<s> ")
+            if text.startswith(prompt):
+                text = text[len(prompt):].removeprefix(" ")
+            else:
+                print("WARNING: prompt not found in the output")
+        return ChunkMetadata(
+            text=text,
+            logprob_tokens=None,
+            completion_tokens=None,
+            prompt_tokens=None,
+            cached_tokens=None,
+        )
+
+
 class TgiProvider(BaseProvider):
     DEFAULT_MODEL_NAME = "<unused>"
 
@@ -972,8 +1067,11 @@ PROVIDER_CLASS_MAP = {
     "vllm": VllmProvider,
     "sglang": VllmProvider,
     "openai": OpenAIProvider,
+    "anyscale": OpenAIProvider,
     "together": TogetherProvider,
     "tgi": TgiProvider,
+    "triton-infer": TritonInferProvider,
+    "triton-generate": TritonGenerateProvider,
 }
 
 
@@ -1812,7 +1910,7 @@ def _(environment, **kw):
             "num_tokens",
             "prompt_tokens",
         ]:
-            entries[metric_name] = environment.stats.entries[(metric_name, "METRIC")].avg_response_time
+            entries[metric_name] = _avg(metric_name)
         if ("cached_tokens", "METRIC") in environment.stats.entries:
             entries["cached_tokens"] = environment.stats.entries[("cached_tokens", "METRIC")].avg_response_time
         if not environment.parsed_options.stream:


### PR DESCRIPTION
## Summary

- **Port `TritonInferProvider`** — non-streaming `/v2/models/{model}/infer` endpoint using Triton's inference format (`inputs` array). Strips the echoed prompt prefix from the response.
- **Port `TritonGenerateProvider`** — streaming + non-streaming `/v2/models/{model}/generate[_stream]` endpoint. Strips echoed prompt prefix in non-streaming mode only.
- **Add `"anyscale": OpenAIProvider`** to `PROVIDER_CLASS_MAP` — same OpenAI-compatible API, different host.
- **Fix quitting summary crash for token-less providers** — the `else` branch in the `@events.quitting` handler was using direct dict access for all text-gen metrics. Providers that don't return token counts (Triton) never emit `completion_tokens`/`num_tokens`, causing a `KeyError`. Fixed by using the existing safe `_avg()` helper.

Both Triton providers structurally cannot report per-token latency — the Triton API returns no token count in its response. `total_latency` and `time_to_first_token` (streaming) are still collected.

## Test plan

- [x] Run `--provider triton-infer --no-stream` against a mock Triton server — confirm requests succeed and `total_latency` is emitted with no `KeyError` in summary
```
locust -f load_test.py --headless \
  -u 1 -r 1 -t 15s \
  --host http://127.0.0.1:8998 \
  --provider triton-infer \
  --no-chat --no-stream \
  --model ensemble \
  --max-tokens 5 \
  --prompt-tokens 20 \
  --tokenizer hf-qwen35-9b \
  --csv /tmp/triton_infer \
  --summary-file /tmp/triton_infer_summary.csv
```
- [x] Run `--provider triton-generate --no-stream` — confirm prompt is stripped from response text
```
locust -f load_test.py --headless \
  -u 1 -r 1 -t 15s \
  --host http://127.0.0.1:8998 \
  --provider triton-generate \
  --no-chat --no-stream \
  --model ensemble \
  --max-tokens 5 \
  --prompt-tokens 20 \
  --tokenizer hf-qwen35-9b \
  --csv /tmp/triton_gen_nostream \
  --summary-file /tmp/triton_gen_nostream_summary.csv
```
No error. 
- [x] Run `--provider triton-generate --stream` — confirm TTFT and `total_latency` are collected
```
locust -f load_test.py --headless \
  -u 1 -r 1 -t 15s \
  --host http://127.0.0.1:8998 \
  --provider triton-generate \
  --no-chat --stream \
  --model ensemble \
  --max-tokens 5 \
  --prompt-tokens 20 \
  --tokenizer hf-qwen35-9b \
  --csv /tmp/triton_gen_stream \
  --summary-file /tmp/triton_gen_stream_summary.csv
```
No error. 
- [x] Run `--provider anyscale` against an Anyscale endpoint — confirm OpenAI-compatible routing works
```
locust -f load_test.py --headless \
  -u 1 -r 1 -t 5s \ 
  --host https://api.fireworks.ai/inference \
  --api-key "$FIREWORKS_API_KEY" \
  --provider anyscale \ 
  -m "accounts/fireworks/models/llama-v3p3-70b-instruct" \
  --tokenizer hf-qwen35-9b \
  --max-tokens 20 \
  --prompt-tokens 50 \ 
  --show-request
``` 
See the absence of perf_metrics_in_response in the request body, confirming it's routing to OpenAI, not Fireworks. 
- [x] Run `--provider fireworks` — confirm no regression from `_avg()` change
```
locust -f load_test.py --headless \
  -u 2 -r 1 -t 30s \
  --host https://api.fireworks.ai/inference \
  --api-key "$FIREWORKS_API_KEY" \
  --provider fireworks \
  -m "accounts/fireworks/models/llama-v3p3-70b-instruct" \
  --tokenizer hf-qwen35-9b \
  --max-tokens 50 \
  --prompt-tokens 100 \
  --summary-file /Users/annichen/Downloads/test_result.csv \
  --csv /Users/annichen/Downloads/ --show-request
```
Made with [Cursor](https://cursor.com)