### PR TITLE
Prefill bench tweaks

### DIFF
--- a/llm_bench/prefill_load_test.py
+++ b/llm_bench/prefill_load_test.py
@@ -66,7 +66,7 @@ def generate_pairs(max_seq_len: int, min_seq_len: int) -> list[tuple[int, int]]:
             c = step * multiplier
             if c <= s:
                 pairs.append((s, c))
-        s *= 2
+        s *= 4
     return pairs
 
 
@@ -280,7 +280,8 @@ def run_benchmark(
                     do_warmup(cached_tokens)
 
                 prompt_texts: list[str] = []
-                batch_size = max(1, min_tokens_to_batch // prompt_tokens)
+                uncached_tokens = prompt_tokens - cached_tokens
+                batch_size = max(1, min_tokens_to_batch // uncached_tokens)
                 for _ in range(batch_size):
                     pair_ids = build_pair_ids(base_ids, tokenizer, chunks, prompt_tokens, cached_tokens, rng)
                     if len(pair_ids) != prompt_tokens:


### PR DESCRIPTION
1. Regression model is pretty much identical when built on reduced set of data points for prefill - it's highly predictable.
2. Make sure we issue enough requests to ensure proper batching when most tokens are cached - use uncached tokens to produce batch size vs all tokens. Otherwise, perf variations are very high.