### PR TITLE
llm_bench: add download_tokenizer.py; fix prompt_tokenizer_tokens AttributeError; add tokenizer fallback

### DIFF
--- a/llm_bench/download_tokenizer.py
+++ b/llm_bench/download_tokenizer.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""
+Download a HuggingFace tokenizer locally given a model's HF id.
+
+Usage:
+    python download_tokenizer.py <hf_model_id> [--output-dir DIR]
+
+Examples:
+    python download_tokenizer.py Qwen/Qwen3-Reranker-8B
+    python download_tokenizer.py Qwen/Qwen3-Reranker-8B --output-dir ./tokenizers/qwen3-reranker-8b
+    python download_tokenizer.py meta-llama/Llama-3.1-8B-Instruct --hf-token $HF_TOKEN
+"""
+
+import argparse
+import os
+import sys
+
+
+def download_tokenizer(model_id: str, output_dir: str, hf_token: str = None):
+    try:
+        from transformers import AutoTokenizer
+    except ImportError:
+        print("Error: transformers is not installed. Run: pip install transformers", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Downloading tokenizer for: {model_id}")
+    print(f"Output directory: {output_dir}")
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    kwargs = {"trust_remote_code": True}
+    if hf_token:
+        kwargs["token"] = hf_token
+
+    tokenizer = AutoTokenizer.from_pretrained(model_id, **kwargs)
+    tokenizer.save_pretrained(output_dir)
+
+    print(f"Tokenizer saved to: {output_dir}")
+    print(f"Pass to load tests with: --tokenizer {output_dir}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Download a HuggingFace tokenizer locally given a model's HF id."
+    )
+    parser.add_argument(
+        "model_id",
+        help="HuggingFace model id (e.g. Qwen/Qwen3-Reranker-8B)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        help="Local directory to save the tokenizer. Defaults to ./tokenizers/<model-name>",
+    )
+    parser.add_argument(
+        "--hf-token",
+        default=os.environ.get("HF_TOKEN"),
+        help="HuggingFace access token for gated models. Falls back to $HF_TOKEN env var.",
+    )
+    args = parser.parse_args()
+
+    output_dir = args.output_dir or os.path.join("tokenizers", args.model_id.split("/")[-1])
+    download_tokenizer(args.model_id, output_dir, args.hf_token)
+
+
+if __name__ == "__main__":
+    main()

--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -48,9 +48,14 @@ def _install_transformers_tokenizer_compat_shim():
         gpt2_module.bytes_to_unicode = bytes_to_unicode
 
 
+DEFAULT_TOKENIZER = "NousResearch/Meta-Llama-3.1-8B"
+
+
 def _load_auto_tokenizer(tokenizer_path: str):
     _install_transformers_tokenizer_compat_shim()
     return transformers.AutoTokenizer.from_pretrained(tokenizer_path, trust_remote_code=True)
+
+
 
 
 def add_custom_metric(name, value, length_value=0):
@@ -73,12 +78,12 @@ class TranslationDataset:
         self,
         path: str,
         prompt: str,
-        tokenizer_path: str,
+        tokenizer,
         chat: bool,
         num_tokens: int,
         common_tokens: int,
     ):
-        self._tokenizer = _load_auto_tokenizer(tokenizer_path)
+        self._tokenizer = tokenizer
         self._num_tokens = num_tokens
 
         self._all_limericks = []
@@ -175,7 +180,6 @@ class DatasetHolder:
                 dataset_limit=getattr(options, "dataset_limit", None),
             )
         elif options.dataset in ("limericks", "code"):
-            assert options.tokenizer is not None, "--tokenizer is required for limericks or code dataset"
             if options.dataset == "limericks":
                 if options.prompt is None:
                     prompt = "Translate the limericks above to Spanish."
@@ -192,7 +196,7 @@ class DatasetHolder:
             return TranslationDataset(
                 path=os.path.join(os.path.dirname(os.path.abspath(__file__)), dataset_file),
                 prompt="\n\n" + prompt,
-                tokenizer_path=options.tokenizer,
+                tokenizer=InitTracker.load_tokenizer(options.tokenizer),
                 chat=options.chat and not getattr(options, "rerank", False),
                 num_tokens=options.prompt_tokens,
                 common_tokens=options.prompt_cache_max_len,
@@ -507,13 +511,14 @@ class InitTracker:
         cls.environment.runner.stats.reset_all()
 
     @classmethod
-    def load_tokenizer(cls, dir):
-        if not dir:
-            return None
+    def load_tokenizer(cls, explicit_path: str):
         if cls.tokenizer:
             return cls.tokenizer
 
-        cls.tokenizer = _load_auto_tokenizer(dir)
+        source = explicit_path or DEFAULT_TOKENIZER
+        if not explicit_path:
+            logger.warning(f"No --tokenizer specified, falling back to default: {DEFAULT_TOKENIZER}")
+        cls.tokenizer = _load_auto_tokenizer(source)
         cls.tokenizer.add_bos_token = False
         cls.tokenizer.add_eos_token = False
         return cls.tokenizer
@@ -1278,6 +1283,9 @@ class LLMUser(HttpUser):
         dataset = DatasetHolder.get_instance(self.environment.parsed_options)
         self.dataset = iter(dataset)
 
+        tokenizer = InitTracker.load_tokenizer(self.environment.parsed_options.tokenizer)
+        self.prompt_tokenizer_tokens = len(tokenizer.encode(self._get_input()[0]))
+
         # Override dataset with synthetic rerank documents if num_documents or tokens_per_document is set
         if self.environment.parsed_options.rerank and (
             getattr(self.environment.parsed_options, "num_documents", None) is not None
@@ -1612,7 +1620,12 @@ def init_parser(parser):
         "--tokenizer",
         env_var="TOKENIZER",
         type=str,
-        help="Specify HF tokenizer to use for validating the output of the model. It's optional, we're going to rely on 'usage' or 'logprobs' field to get token count information",
+        help=(
+            "Tokenizer for counting prompt tokens. Accepts a local directory path or a HuggingFace model ID "
+            f"(e.g. 'Qwen/Qwen3.5-9B' or './tokenizers/Llama-3.1-8B-Instruct'). "
+            f"If omitted, defaults to '{DEFAULT_TOKENIZER}' (downloaded from HF on first use and cached locally). "
+            "Use download_tokenizer.py to pre-download a tokenizer for offline or CI use."
+        ),
     )
     parser.add_argument(
         "--chat",


### PR DESCRIPTION
## Summary

- **Add `download_tokenizer.py`**: CLI tool to pre-download a HuggingFace tokenizer to a local directory for offline/CI use. Accepts a HF model ID and optional `--output-dir` and `--hf-token`. A script ported from Customers/ repo. 
- **Fix `AttributeError` on missing `self.prompt_tokenizer_tokens`**: Before this PR, `self.prompt_tokenizer_tokens` was never initialized in `LLMUser._on_start`. When a server (e.g. Triton) omits `usage.prompt_tokens` from its response, the fallback at `prompt_tokens = prompt_tokens or self.prompt_tokenizer_tokens` raises `AttributeError: 'LLMUser' object has no attribute 'prompt_tokenizer_tokens'`, silently killing the greenlet. This PR always sets `self.prompt_tokenizer_tokens` to a real integer.
- **Tokenizer fallback — `--tokenizer` is now optional**: Previously, omitting `--tokenizer` crashed at startup with `AssertionError: --tokenizer is required for limericks or code dataset`. Now `load_tokenizer` falls back to `NousResearch/Meta-Llama-3.1-8B` (an ungated public HF mirror of Llama 3.1 8B with an identical tokenizer), downloaded from HF on first use and cached locally. No `HF_TOKEN` required.
- **Tokenizer loaded once and reused**: `TranslationDataset` now accepts a pre-loaded tokenizer object from `InitTracker` instead of loading from path independently, so the tokenizer is only downloaded/initialized once per process.
- **Improved `--tokenizer` help text**: Clarifies that the flag accepts a local path or HF model ID, describes the default fallback, and points to `download_tokenizer.py` for pre-downloading.

## Test plan

Tested all three tokenizer paths against a local mock Triton server:

1. **Explicit local path** — tokenizer pre-downloaded to disk:
```
locust -f llm_bench/load_test.py --host http://127.0.0.1:8998 --provider triton-generate --model my-model \
  --tokenizer llm_bench/hf-qwen35-9b --prompt-tokens 20 --max-tokens 10 --no-chat --headless -u 1 -r 1 --run-time 10s
```

2. **No `--tokenizer` flag** — falls back to `NousResearch/Meta-Llama-3.1-8B`, downloads from HF on first run:
```
locust -f llm_bench/load_test.py --host http://127.0.0.1:8998 --provider triton-generate --model my-model \
  --prompt-tokens 20 --max-tokens 10 --no-chat --headless -u 1 -r 1 --run-time 10s
```
￼
<img width="1089" height="43" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/e0e0c217-c008-4fa9-aca6-5fd80930eca5" />
See it appears under huggingface cache. 

3. **HF model ID** — downloads tokenizer from HuggingFace at startup:
```
locust -f llm_bench/load_test.py --host http://127.0.0.1:8998 --provider triton-generate --model my-model \
  --tokenizer Qwen/Qwen3.5-9B --prompt-tokens 20 --max-tokens 10 --no-chat --headless -u 1 -r 1 --run-time 10s
```
Similarly, I see tokenizer is downloaded in huggingface cache. 


All three paths completed successfully with correct `prompt_tokens` metrics in the output.

- [x] Tested that download_tokenizer.py script works
`python llm_bench/download_tokenizer.py NousResearch/Meta-Llama-3.1-8B --output-dir ./tokenizers/llama-3.1-8b`
