### PR TITLE
llm_bench: fix rerank response parsing, anyscale auto-detection, reasoning-effort validation

### DIFF
--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -730,7 +730,7 @@ class OpenAIProvider(BaseProvider):
     def parse_output_json(self, data):
         if self.parsed_options.rerank:
             usage = data.get("usage", {})
-            scores = [f"{item['index']}:{item['relevance_score']:.4f}" for item in data.get("data", [])]
+            scores = [f"{item['index']}:{item['relevance_score']:.4f}" for item in data.get("results", data.get("data", []))]
             return ChunkMetadata(
                 text=", ".join(scores),
                 logprob_tokens=None,
@@ -1136,6 +1136,8 @@ class LLMUser(HttpUser):
                 self.provider = "together"
             elif "openai" in self.host:
                 self.provider = "openai"
+            elif "anyscale" in self.host:
+                self.provider = "anyscale"
 
         if (
             self.model is None
@@ -1905,7 +1907,8 @@ def init_parser(parser):
         "--reasoning-effort",
         type=str,
         default=None,
-        help="Set the reasoning_effort parameter for the API request (e.g., 'none', 'low', 'medium', 'high'). "
+        choices=["low", "medium", "high"],
+        help="Set the reasoning_effort parameter for the API request. "
         "If not specified and using a JSONL dataset, will use the value from the dataset if present.",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary

- **Rerank response parsing**: `parse_output_json` now tries `data.get("results", data.get("data", []))` to handle both `{"data": [...]}` and `{"results": [...]}` response shapes. Previously, servers using the `results` key silently returned empty scores.
- **Anyscale URL auto-detection**: `_guess_provider` now detects `"anyscale"` in the host URL. `AnyscaleProvider` was already registered in `PROVIDER_CLASS_MAP` but omitting `--provider` against an Anyscale endpoint would crash at startup.
- **`--reasoning-effort` validation**: Added `choices=["low", "medium", "high"]` so invalid values are rejected at startup instead of being silently forwarded to the API.

## Test plan

**Rerank:**
- Run rerank against a server returning `{"results": [...]}` — scores should appear in output (previously empty).
- Run against Fireworks (`{"data": [...]}`) — confirm no regression.

**Anyscale auto-detection:**
- Run without `--provider` against a host with `"anyscale"` in the URL — confirm `AnyscaleProvider` is picked automatically.

**`--reasoning-effort` validation:**
```bash
# Should fail immediately with a clear argparse error:
locust -f llm_bench/load_test.py --host http://... --reasoning-effort invalid ...

# Should work:
locust -f llm_bench/load_test.py --host http://... --reasoning-effort low ...
```

Made with [Cursor](https://cursor.com)