### PR TITLE
Benchmark stability improvements

### DIFF
--- a/llm_bench/gen_load_test.py
+++ b/llm_bench/gen_load_test.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 """
-Generation (decode) latency benchmark for Fireworks /v1/chat/completions.
+Generation (decode) latency benchmark for Fireworks /v1/completions.
 
-For each (seq_len, batch_size) pair, sends a single prompt of length seq_len
-with n=batch_size and max_tokens output tokens, then reports per-forward-pass
-generation latency derived from fireworks-generation-duration and the number
-of target-model forward passes (speculation-aware).
+For each (seq_len, batch_size) pair, builds a single user message wrapped in
+the model's chat template (applied client-side via the HF tokenizer), sends
+the resulting token-id prompt with n=batch_size and max_tokens output tokens,
+then reports per-forward-pass generation latency derived from
+fireworks-generation-duration and the number of target-model forward passes
+(speculation-aware).
 """
 
 from __future__ import annotations
@@ -88,36 +90,6 @@ def _load_auto_tokenizer(tokenizer_path: str) -> transformers.PreTrainedTokenize
     return transformers.AutoTokenizer.from_pretrained(tokenizer_path, trust_remote_code=True)
 
 
-def get_chat_template_overhead_tokens(
-    session: requests.Session,
-    url: str,
-    api_key: str,
-    model: Optional[str],
-    temperature: Optional[float],
-) -> int:
-    """Measure server-side chat template overhead via a single-token calibration request."""
-    r = post_chat_completion(
-        session,
-        url,
-        api_key,
-        model,
-        "x",
-        max_tokens=1,
-        n=1,
-        temperature=temperature,
-    )
-    if r.status_code != 200:
-        raise RuntimeError(f"Calibration request failed HTTP {r.status_code}: {r.text[:500]}")
-
-    server_tokens = get_int_header(r.headers, "prompt-tokens")
-    if server_tokens is None:
-        raise RuntimeError(
-            "Missing fireworks-prompt-tokens header in calibration response; "
-            "cannot determine chat template overhead."
-        )
-    return server_tokens + 1
-
-
 def _dataset_path(dataset: str) -> str:
     name = "limericks.txt" if dataset == "limericks" else "code.txt"
     return os.path.join(os.path.dirname(os.path.abspath(__file__)), name)
@@ -139,18 +111,96 @@ _DATASET_SUFFIXES = {
 }
 
 
-def build_ids_to_length(
+def build_chunk_texts_to_length(
     tokenizer: transformers.PreTrainedTokenizer,
     chunks: list[str],
     target_len: int,
-) -> list[int]:
-    ids: list[int] = []
+) -> list[str]:
+    """Cycle chunks (each followed by `\\n\\n`) until total tokens reach `target_len`.
+
+    Returns one chunk text per element so callers can slice at chunk granularity
+    (never cutting a chunk mid-text).
+    """
+    out: list[str] = []
+    total = 0
     i = 0
-    while len(ids) < target_len and i < 1_000_000:
-        lim = chunks[i % len(chunks)]
-        ids.extend(tokenizer.encode(lim + "\n\n"))
+    while total < target_len and i < 1_000_000:
+        text = chunks[i % len(chunks)] + "\n\n"
+        out.append(text)
+        total += len(tokenizer.encode(text))
         i += 1
-    return ids[:target_len]
+    return out
+
+
+def apply_chat_template_ids(
+    tokenizer: transformers.PreTrainedTokenizer,
+    content_text: str,
+) -> list[int]:
+    """Apply the model's chat template to a single user message and return token ids."""
+    out = tokenizer.apply_chat_template(
+        [{"role": "user", "content": content_text}],
+        tokenize=True,
+        add_generation_prompt=True,
+    )
+    return _normalize_ids(out)
+
+
+def _normalize_ids(obj: Any) -> list[int]:
+    """Normalize tokenizer output (list, Encoding, BatchEncoding, tensor) to a plain list[int]."""
+    ids = getattr(obj, "ids", None)
+    if ids is not None:
+        return [int(t) for t in ids]
+    input_ids = getattr(obj, "input_ids", None)
+    if input_ids is not None:
+        seq = (
+            input_ids[0]
+            if hasattr(input_ids, "__len__") and len(input_ids) and hasattr(input_ids[0], "__iter__")
+            else input_ids
+        )
+        return [int(t) for t in seq]
+    tolist = getattr(obj, "tolist", None)
+    if callable(tolist):
+        flat = tolist()
+        if flat and isinstance(flat[0], list):
+            flat = flat[0]
+        return [int(t) for t in flat]
+    return [int(t) for t in obj]
+
+
+def build_chat_prompt_ids(
+    tokenizer: transformers.PreTrainedTokenizer,
+    suffix_text: str,
+    chunk_texts: list[str],
+    target_len: int,
+) -> list[int]:
+    """Build chat-templated prompt ids of at most `target_len` tokens, chunk-aligned.
+
+    Bisects on chunk count to find the largest k such that the chat-templated
+    tokenization of `chunks[:k] + suffix` stays within `target_len`. This is
+    exact (no token-count estimation drift from chat template wrapping) at the
+    cost of O(log n) chat template tokenizations.
+    """
+    if not chunk_texts:
+        raise ValueError("no chunks provided")
+
+    def length_for(k: int) -> int:
+        return len(apply_chat_template_ids(tokenizer, "".join(chunk_texts[:k]) + suffix_text))
+
+    if length_for(1) > target_len:
+        raise ValueError(f"target_len={target_len} too small to fit even one chunk")
+
+    n = len(chunk_texts)
+    if length_for(n) <= target_len:
+        return apply_chat_template_ids(tokenizer, "".join(chunk_texts) + suffix_text)
+
+    lo, hi = 1, n
+    while lo < hi:
+        mid = (lo + hi + 1) // 2
+        if length_for(mid) <= target_len:
+            lo = mid
+        else:
+            hi = mid - 1
+    return apply_chat_template_ids(tokenizer, "".join(chunk_texts[:lo]) + suffix_text)
 
 
 def get_header(headers: Mapping[str, str], short_key: str) -> Optional[float]:
@@ -175,8 +225,8 @@ def get_int_header(headers: Mapping[str, str], short_key: str) -> Optional[int]:
         return None
 
 
-def chat_completions_url(base_url: str) -> str:
-    return base_url.rstrip("/") + "/v1/chat/completions"
+def completions_url(base_url: str) -> str:
+    return base_url.rstrip("/") + "/v1/completions"
 
 
 def parse_pairs_arg(s: str) -> list[tuple[int, int]]:
@@ -196,19 +246,19 @@ def parse_int_list(s: str) -> list[int]:
     return [int(x.strip()) for x in s.split(",") if x.strip()]
 
 
-def post_chat_completion(
+def post_completion(
     session: requests.Session,
     url: str,
     api_key: str,
     model: Optional[str],
-    prompt: str,
+    prompt: list[int],
     max_tokens: int,
     n: int,
     temperature: Optional[float] = None,
     user: Optional[str] = None,
 ) -> requests.Response:
     payload: dict[str, Any] = {
-        "messages": [{"role": "user", "content": prompt}],
+        "prompt": prompt,
         "max_tokens": max_tokens,
         "n": n,
         "stream": False,
@@ -253,7 +303,7 @@ def _run_pair_n_mode(
     url: str,
     api_key: str,
     model: Optional[str],
-    prompt_text: str,
+    prompt_ids: list[int],
     max_tokens: int,
     seq_len: int,
     batch_size: int,
@@ -269,12 +319,12 @@ def _run_pair_n_mode(
     )
 
     wall_start = time.perf_counter()
-    r = post_chat_completion(
+    r = post_completion(
         session,
         url,
         api_key,
         model,
-        prompt_text,
+        prompt_ids,
         max_tokens=max_tokens,
         n=batch_size,
         temperature=temperature,
@@ -318,7 +368,7 @@ def _run_pair_separate_mode(
     url: str,
     api_key: str,
     model: Optional[str],
-    prompt_text: str,
+    prompt_ids: list[int],
     max_tokens: int,
     seq_len: int,
     batch_size: int,
@@ -335,12 +385,12 @@ def _run_pair_separate_mode(
 
     def _single_request() -> requests.Response:
         s = requests.Session()
-        return post_chat_completion(
+        return post_completion(
             s,
             url,
             api_key,
             model,
-            prompt_text,
+            prompt_ids,
             max_tokens=max_tokens,
             n=1,
             temperature=temperature,
@@ -392,6 +442,63 @@ def _run_pair_separate_mode(
     )
 
 
+def _warmup_seq_len(
+    *,
+    url: str,
+    api_key: str,
+    model: Optional[str],
+    prompt_ids: list[int],
+    seq_len: int,
+    concurrency: int,
+    temperature: Optional[float],
+    retries: int,
+    retry_delay: float,
+) -> None:
+    """Issue `concurrency` warmup completions in parallel for the same prompt."""
+
+    def _single() -> requests.Response:
+        return post_completion(
+            requests.Session(),
+            url,
+            api_key,
+            model,
+            prompt_ids,
+            max_tokens=0,
+            n=1,
+            temperature=temperature,
+        )
+
+    for attempt in range(1, retries + 1):
+        logger.info(
+            "Warmup (seq_len=%d, concurrency=%d, attempt %d/%d) ...",
+            seq_len,
+            concurrency,
+            attempt,
+            retries,
+        )
+        if concurrency == 1:
+            responses = [_single()]
+        else:
+            with ThreadPoolExecutor(max_workers=concurrency) as pool:
+                futures = [pool.submit(_single) for _ in range(concurrency)]
+                responses = [f.result() for f in as_completed(futures)]
+
+        bad = next((r for r in responses if r.status_code != 200), None)
+        if bad is None:
+            return
+        if attempt < retries:
+            logger.warning(
+                "Warmup seq_len=%d failed HTTP %d: %s. Retrying in %.0fs ...",
+                seq_len,
+                bad.status_code,
+                bad.text[:500],
+                retry_delay,
+            )
+            time.sleep(retry_delay)
+        else:
+            raise RuntimeError(f"Warmup seq_len={seq_len} failed HTTP {bad.status_code}: {bad.text[:500]}")
+
+
 def run_benchmark(
     tokenizer_path: str,
     model: Optional[str],
@@ -402,7 +509,7 @@ def run_benchmark(
     max_tokens: int,
     temperature: Optional[float] = None,
     separate_requests: bool = False,
-    warmup_requests: int = 1,
+    warmup_concurrency: Optional[int] = None,
     retries: int = 3,
     retry_delay: float = 30.0,
 ) -> list[GenBenchmarkResult]:
@@ -411,62 +518,49 @@ def run_benchmark(
     chunks = load_chunks(dataset)
     suffix = _DATASET_SUFFIXES.get(dataset, "")
 
-    suffix_ids = tokenizer.encode(suffix) if suffix else []
-    prefix_ids = build_ids_to_length(tokenizer, chunks, max_seq)
-    if len(prefix_ids) + len(suffix_ids) < max_seq:
-        raise RuntimeError(f"Could only build {len(prefix_ids) + len(suffix_ids)} tokens from dataset, need {max_seq}")
+    chunk_texts = build_chunk_texts_to_length(tokenizer, chunks, max_seq)
 
-    url = chat_completions_url(base_url)
+    url = completions_url(base_url)
     session = requests.Session()
-
-    chat_overhead = get_chat_template_overhead_tokens(
-        session,
-        url,
-        api_key,
-        model,
-        temperature,
-    )
-    logger.info("Chat template overhead: %d tokens (server-calibrated)", chat_overhead)
 
     if separate_requests:
         logger.info("Mode: separate concurrent requests (no n>1)")
     else:
         logger.info("Mode: single request with n=batch_size")
 
-    warmup_seq_len = max(seq_len for seq_len, _ in pairs)
-    warmup_prompt_ids = prefix_ids[: warmup_seq_len - chat_overhead - max_tokens - len(suffix_ids)] + suffix_ids
-    warmup_prompt_text = tokenizer.decode(warmup_prompt_ids)
-    for i in range(1, warmup_requests + 1):
-        for attempt in range(1, retries + 1):
-            logger.info(
-                "Warmup %d/%d (seq_len=%d, attempt %d/%d) ...", i, warmup_requests, warmup_seq_len, attempt, retries
-            )
-            w = post_chat_completion(
-                session,
-                url,
-                api_key,
-                model,
-                warmup_prompt_text,
-                max_tokens=1,
-                n=1,
-                temperature=temperature,
-            )
-            if w.status_code == 200:
-                break
-            if attempt < retries:
-                logger.warning(
-                    "Warmup %d failed HTTP %d: %s. Retrying in %.0fs ...", i, w.status_code, w.text[:500], retry_delay
-                )
-                time.sleep(retry_delay)
-            else:
-                raise RuntimeError(f"Warmup {i} failed HTTP {w.status_code}: {w.text[:500]}")
-    logger.info("Warmup complete")
+    if warmup_concurrency is None:
+        warmup_concurrency = 64 if separate_requests else 1
+    logger.info("Warmup concurrency: %d", warmup_concurrency)
 
     results: list[GenBenchmarkResult] = []
+    prev_seq_len: Optional[int] = None
 
+    # Sort by seq_len descending so all batches for the same seq_len are grouped
+    # (one warmup per seq_len) and longer prompts come first for full prompt-cache hit rate.
+    pairs = sorted(pairs, key=lambda p: (-p[0], p[1]))
+
+    prompt_ids: list[int] = []
     for seq_len, batch_size in pairs:
-        prompt_ids = prefix_ids[: seq_len - chat_overhead - max_tokens - len(suffix_ids)] + suffix_ids
-        prompt_text = tokenizer.decode(prompt_ids)
+        if seq_len != prev_seq_len:
+            prompt_ids = build_chat_prompt_ids(
+                tokenizer,
+                suffix,
+                chunk_texts,
+                target_len=seq_len - max_tokens,
+            )
+            logger.info("Built prompt for seq_len=%d: %d tokens", seq_len, len(prompt_ids))
+            _warmup_seq_len(
+                url=url,
+                api_key=api_key,
+                model=model,
+                prompt_ids=prompt_ids,
+                seq_len=seq_len,
+                concurrency=warmup_concurrency,
+                temperature=temperature,
+                retries=retries,
+                retry_delay=retry_delay,
+            )
+            prev_seq_len = seq_len
 
         for attempt in range(1, retries + 1):
             try:
@@ -475,7 +569,7 @@ def run_benchmark(
                         url=url,
                         api_key=api_key,
                         model=model,
-                        prompt_text=prompt_text,
+                        prompt_ids=prompt_ids,
                         max_tokens=max_tokens,
                         seq_len=seq_len,
                         batch_size=batch_size,
@@ -487,7 +581,7 @@ def run_benchmark(
                         url=url,
                         api_key=api_key,
                         model=model,
-                        prompt_text=prompt_text,
+                        prompt_ids=prompt_ids,
                         max_tokens=max_tokens,
                         seq_len=seq_len,
                         batch_size=batch_size,
@@ -539,7 +633,7 @@ def main() -> None:
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
         stream=sys.stderr,
     )
-    parser = argparse.ArgumentParser(description="Generation (decode) latency benchmark (Fireworks chat completions).")
+    parser = argparse.ArgumentParser(description="Generation (decode) latency benchmark (Fireworks completions).")
     parser.add_argument(
         "--tokenizer",
         required=True,
@@ -628,12 +722,11 @@ def main() -> None:
         "instead of a single request with n=batch_size.",
     )
     parser.add_argument(
-        "--warmup-requests",
+        "--warmup-concurrency",
         type=int,
         default=None,
-        help="Number of warmup requests to send before running pairs "
-        "(default: 64 if --separate-requests, else 4). "
-        "Each warmup uses the max context length across all pairs. Keep it large enough to make sure that all in case of inline DP all generators are warmed up",
+        help="Number of identical warmup requests to send in parallel before each new "
+        "seq_len group (default: 64 if --separate-requests, else 1).",
     )
     parser.add_argument(
         "--retries",
@@ -674,17 +767,11 @@ def main() -> None:
         batch_sizes = get_profile_batch_sizes(args.max_batch_size)
         pairs = [(s, b) for s in seq_lens for b in batch_sizes]
 
-    if args.warmup_requests is None:
-        args.warmup_requests = 64 if args.separate_requests else 4
-
     if args.max_kv_cache_entries is not None:
         pairs = [(s, b) for s, b in pairs if (s + args.max_tokens) * b <= args.max_kv_cache_entries]
 
     if len(pairs) == 0:
         raise RuntimeError("No seq:batch pairs")
-
-    # Sort by seq_len descending to guarantee full prompt cache hit rate.
-    pairs.sort(key=lambda p: p[0], reverse=True)
 
     logger.info("Using %d seq-batch pairs: %s", len(pairs), pairs)
 
@@ -698,7 +785,7 @@ def main() -> None:
         max_tokens=args.max_tokens,
         temperature=args.temperature,
         separate_requests=args.separate_requests,
-        warmup_requests=args.warmup_requests,
+        warmup_concurrency=args.warmup_concurrency,
         retries=args.retries,
         retry_delay=args.retry_delay,
     )

--- a/llm_bench/prefill_load_test.py
+++ b/llm_bench/prefill_load_test.py
@@ -221,7 +221,7 @@ def post_completion(
     url: str,
     api_key: str,
     model: Optional[str],
-    prompt: str | list[str],
+    prompt: str | list[str] | list[int] | list[list[int]],
     max_tokens: int,
     prompt_cache_max_len: int | None = None,
 ) -> requests.Response:
@@ -266,8 +266,7 @@ def run_benchmark(
     session = requests.Session()
 
     def do_warmup(cached_tokens: int) -> None:
-        warmup_prompt = tokenizer.decode(base_ids[:cached_tokens], skip_special_tokens=True)
-        w = post_completion(session, url, api_key, model, warmup_prompt, max_tokens)
+        w = post_completion(session, url, api_key, model, base_ids[:cached_tokens], max_tokens)
         if w.status_code != 200:
             raise RuntimeError(f"Warmup failed HTTP {w.status_code}: {w.text[:500]}")
 
@@ -283,24 +282,26 @@ def run_benchmark(
                 if cached_tokens > 0:
                     do_warmup(cached_tokens)
 
-                prompt_texts: list[str] = []
+                prompt_token_ids: list[list[int]] = []
                 uncached_tokens = prompt_tokens - cached_tokens
                 batch_size = max(1, min_tokens_to_batch // uncached_tokens)
                 for _ in range(batch_size):
                     pair_ids = build_pair_ids(base_ids, tokenizer, chunks, prompt_tokens, cached_tokens, rng)
                     if len(pair_ids) != prompt_tokens:
                         raise RuntimeError(f"pair_ids length {len(pair_ids)} != prompt_tokens {prompt_tokens}")
-                    prompt_texts.append(tokenizer.decode(pair_ids[:-2], skip_special_tokens=True))
+                    # Send pre-tokenized ids (drop trailing 2 ids to mirror the previous decode-then-retokenize
+                    # truncation, and to avoid feeding a partial last subword token to the model).
+                    prompt_token_ids.append(pair_ids[:-2])
 
                 logger.info(
                     "Pair (%d, %d): sending %d prompts in one request",
                     prompt_tokens,
                     cached_tokens,
-                    len(prompt_texts),
+                    len(prompt_token_ids),
                 )
                 wall_start = time.perf_counter()
                 r = post_completion(
-                    session, url, api_key, model, prompt_texts, max_tokens, prompt_cache_max_len=cached_tokens
+                    session, url, api_key, model, prompt_token_ids, max_tokens, prompt_cache_max_len=cached_tokens
                 )
                 if r.status_code != 200:
                     raise RuntimeError(f"Request failed HTTP {r.status_code}: {r.text[:500]}")
@@ -329,7 +330,7 @@ def run_benchmark(
                     PairBenchmarkResult(
                         prompt_tokens=prompt_tokens,
                         cached_tokens=cached_tokens,
-                        num_prompts=len(prompt_texts),
+                        num_prompts=len(prompt_token_ids),
                         duration=st,
                         client_duration=wall,
                         mean_fireworks_prompt_tokens=fwp,
@@ -469,7 +470,7 @@ def main() -> None:
     parser.add_argument(
         "--min-tokens-to-batch",
         type=int,
-        default=65536,
+        default=131072,
         help="Minimum total prompt tokens to accumulate per batch (default 64K).",
     )
     parser.add_argument("--max-tokens", type=int, default=0, help="max_tokens for completions (default 0).")

--- a/llm_bench/prefill_load_test.py
+++ b/llm_bench/prefill_load_test.py
@@ -4,6 +4,12 @@ Prefill benchmark for Fireworks /v1/completions.
 
 For each (prompt_tokens, cached_tokens) pair, warms the KV cache and sends a batch
 of prompts as a single multi-prompt request, reporting server and client durations.
+
+Each prompt is wrapped client-side in the model's chat template (a single user
+message with the generation prompt appended) and sent as token ids. The chat
+template is split into prefix/suffix token lists so cached_tokens corresponds to
+the exact length of the shared head (chat_prefix + shared content) across all
+prompts in a batch and the warmup call.
 """
 
 from __future__ import annotations
@@ -122,7 +128,58 @@ def build_random_suffix_ids(
     return ids[:need_len]
 
 
+def _normalize_ids(obj: Any) -> list[int]:
+    """Normalize tokenizer output (list, Encoding, BatchEncoding, tensor) to a plain list[int]."""
+    ids = getattr(obj, "ids", None)
+    if ids is not None:
+        return [int(t) for t in ids]
+    input_ids = getattr(obj, "input_ids", None)
+    if input_ids is not None:
+        seq = (
+            input_ids[0]
+            if hasattr(input_ids, "__len__") and len(input_ids) and hasattr(input_ids[0], "__iter__")
+            else input_ids
+        )
+        return [int(t) for t in seq]
+    tolist = getattr(obj, "tolist", None)
+    if callable(tolist):
+        flat = tolist()
+        if flat and isinstance(flat[0], list):
+            flat = flat[0]
+        return [int(t) for t in flat]
+    return [int(t) for t in obj]
+
+
+def split_chat_template(
+    tokenizer: transformers.PreTrainedTokenizer,
+) -> tuple[list[int], list[int]]:
+    """Return (prefix_ids, suffix_ids) for the chat template wrapping a single user message.
+
+    Templates a multi-token sentinel content, locates it in the templated id sequence,
+    and returns the surrounding prefix and suffix token lists. Lets us compose
+    `prefix + content_ids + suffix` directly without round-tripping through text.
+    """
+    sentinel = "abcdefghij"
+    sentinel_ids = _normalize_ids(tokenizer.encode(sentinel, add_special_tokens=False))
+    if not sentinel_ids:
+        raise RuntimeError("Sentinel tokenized to empty id list; cannot split chat template.")
+    templated = _normalize_ids(
+        tokenizer.apply_chat_template(
+            [{"role": "user", "content": sentinel}],
+            tokenize=True,
+            add_generation_prompt=True,
+        )
+    )
+    n = len(sentinel_ids)
+    for i in range(len(templated) - n + 1):
+        if templated[i : i + n] == sentinel_ids:
+            return templated[:i], templated[i + n :]
+    raise RuntimeError(f"Could not locate sentinel ids {sentinel_ids} in templated ids {templated}")
+
+
 def build_pair_ids(
+    chat_prefix_ids: list[int],
+    chat_suffix_ids: list[int],
     base_ids: list[int],
     tokenizer: transformers.PreTrainedTokenizer,
     chunks: list[str],
@@ -130,18 +187,52 @@ def build_pair_ids(
     cached_tokens: int,
     rng: random.Random,
 ) -> list[int]:
-    max_seq = len(base_ids)
-    if cached_tokens > max_seq:
-        raise ValueError(f"cached_tokens {cached_tokens} exceeds warmup length {max_seq}")
-    if prompt_tokens > max_seq:
-        raise ValueError(f"prompt_tokens {prompt_tokens} exceeds max_seq_len {max_seq}")
-    shared = base_ids[:cached_tokens]
-    need_suffix = prompt_tokens - cached_tokens
-    if need_suffix <= 0:
-        return shared[:prompt_tokens]
-    suffix_ids = build_random_suffix_ids(tokenizer, chunks, need_suffix, rng)
-    combined = shared + suffix_ids
-    return combined[:prompt_tokens]
+    """Build a chat-templated prompt id sequence of exactly `prompt_tokens` tokens.
+
+    Layout: chat_prefix_ids ++ shared_content ++ random_content ++ chat_suffix_ids,
+    truncated to `prompt_tokens`. The first `cached_tokens` ids are deterministically
+    shared across all prompts in the batch (and across warmup), so the prompt cache
+    hits exactly `cached_tokens` tokens.
+    """
+    chat_overhead = len(chat_prefix_ids) + len(chat_suffix_ids)
+    if prompt_tokens < chat_overhead:
+        raise ValueError(f"prompt_tokens {prompt_tokens} is smaller than chat overhead {chat_overhead}")
+    if cached_tokens > prompt_tokens:
+        raise ValueError(f"cached_tokens {cached_tokens} exceeds prompt_tokens {prompt_tokens}")
+
+    content_target = prompt_tokens - chat_overhead
+    shared_content_len = max(0, cached_tokens - len(chat_prefix_ids))
+    shared_content_len = min(shared_content_len, content_target)
+
+    if shared_content_len > len(base_ids):
+        raise ValueError(f"shared_content_len {shared_content_len} exceeds base_ids length {len(base_ids)}")
+
+    shared = base_ids[:shared_content_len]
+    need_random = content_target - shared_content_len
+    random_ids = build_random_suffix_ids(tokenizer, chunks, need_random, rng)
+    content = shared + random_ids
+    if len(content) < content_target:
+        raise RuntimeError(f"Could not build {content_target} content tokens from dataset (got {len(content)})")
+
+    return chat_prefix_ids + content[:content_target] + chat_suffix_ids
+
+
+def build_warmup_ids(
+    chat_prefix_ids: list[int],
+    base_ids: list[int],
+    cached_tokens: int,
+) -> list[int]:
+    """Warmup prompt = first `cached_tokens` of the shared template + content prefix.
+
+    Sending this as a /v1/completions prompt populates the prompt cache up to exactly
+    `cached_tokens` tokens, matching the head of every per-pair prompt built above.
+    """
+    if cached_tokens <= len(chat_prefix_ids):
+        return chat_prefix_ids[:cached_tokens]
+    extra = cached_tokens - len(chat_prefix_ids)
+    if extra > len(base_ids):
+        raise ValueError(f"cached_tokens {cached_tokens} exceeds chat_prefix + base_ids capacity")
+    return chat_prefix_ids + base_ids[:extra]
 
 
 def parse_pairs_arg(s: str) -> list[tuple[int, int]]:
@@ -258,6 +349,15 @@ def run_benchmark(
     max_seq = max(prompt_tokens for prompt_tokens, _ in pairs)
     chunks = load_chunks(dataset)
 
+    chat_prefix_ids, chat_suffix_ids = split_chat_template(tokenizer)
+    chat_overhead = len(chat_prefix_ids) + len(chat_suffix_ids)
+    logger.info(
+        "Chat template: %d prefix tokens + %d suffix tokens = %d overhead",
+        len(chat_prefix_ids),
+        len(chat_suffix_ids),
+        chat_overhead,
+    )
+
     base_ids = build_ids_to_length(tokenizer, chunks, max_seq)
     if len(base_ids) != max_seq:
         raise RuntimeError(f"Internal error: base_ids length {len(base_ids)} != max_seq {max_seq}")
@@ -266,7 +366,8 @@ def run_benchmark(
     session = requests.Session()
 
     def do_warmup(cached_tokens: int) -> None:
-        w = post_completion(session, url, api_key, model, base_ids[:cached_tokens], max_tokens)
+        warmup_ids = build_warmup_ids(chat_prefix_ids, base_ids, cached_tokens)
+        w = post_completion(session, url, api_key, model, warmup_ids, max_tokens)
         if w.status_code != 200:
             raise RuntimeError(f"Warmup failed HTTP {w.status_code}: {w.text[:500]}")
 
@@ -276,6 +377,11 @@ def run_benchmark(
     for prompt_tokens, cached_tokens in pairs:
         if not (0 <= cached_tokens <= prompt_tokens):
             raise ValueError(f"Invalid pair ({prompt_tokens}, {cached_tokens}): need 0 <= cached <= prompt")
+        if prompt_tokens < chat_overhead:
+            raise ValueError(
+                f"prompt_tokens {prompt_tokens} smaller than chat template overhead {chat_overhead}; "
+                "skip this pair or raise the prompt length."
+            )
 
         for attempt in range(1, retries + 1):
             try:
@@ -286,12 +392,19 @@ def run_benchmark(
                 uncached_tokens = prompt_tokens - cached_tokens
                 batch_size = max(1, min_tokens_to_batch // uncached_tokens)
                 for _ in range(batch_size):
-                    pair_ids = build_pair_ids(base_ids, tokenizer, chunks, prompt_tokens, cached_tokens, rng)
+                    pair_ids = build_pair_ids(
+                        chat_prefix_ids,
+                        chat_suffix_ids,
+                        base_ids,
+                        tokenizer,
+                        chunks,
+                        prompt_tokens,
+                        cached_tokens,
+                        rng,
+                    )
                     if len(pair_ids) != prompt_tokens:
                         raise RuntimeError(f"pair_ids length {len(pair_ids)} != prompt_tokens {prompt_tokens}")
-                    # Send pre-tokenized ids (drop trailing 2 ids to mirror the previous decode-then-retokenize
-                    # truncation, and to avoid feeding a partial last subword token to the model).
-                    prompt_token_ids.append(pair_ids[:-2])
+                    prompt_token_ids.append(pair_ids)
 
                 logger.info(
                     "Pair (%d, %d): sending %d prompts in one request",
@@ -477,8 +590,8 @@ def main() -> None:
     parser.add_argument(
         "--seed",
         type=int,
-        default=None,
-        help="RNG seed for random limericks/code draws in non-cached suffixes (default: nondeterministic).",
+        default=0,
+        help="RNG seed for random limericks/code draws in non-cached suffixes (default: 0).",
     )
     parser.add_argument(
         "-f",


### PR DESCRIPTION
Prefill:
* increase number of tokens to 128K for better stability
* use tokenized ids to bypass tokenizer, this makes batching delay smaller

Generation:
* use tokenized ids with prompt templates. do not cut off prompts: for some models it leads to cut-off generations