### PR TITLE
llm_bench: always send prompt_cache_max_len in request payload

### DIFF
--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -897,8 +897,7 @@ class FireworksProvider(OpenAIProvider):
             data["min_tokens"] = max_tokens
         # Enable perf_metrics_in_response to get speculation stats in streaming responses
         data["perf_metrics_in_response"] = True
-        if self.parsed_options.prompt_cache_max_len:
-            data["prompt_cache_max_len"] = self.parsed_options.prompt_cache_max_len
+        data["prompt_cache_max_len"] = self.parsed_options.prompt_cache_max_len
         if self._acceptance_probs_override is not None:
             data["acceptance_probs_override"] = self._acceptance_probs_override
         if self._forced_generation_pool is not None:


### PR DESCRIPTION
## Summary
- Always include `prompt_cache_max_len` in the Fireworks request payload, even when it's 0.
- Cache-busting already works via randomized prompt construction for `limericks`/`code` datasets. This change makes the intent explicit to the server as a defense-in-depth measure, so that even if prompt construction is ever broken, the server still respects the 0-cache setting.

## Context
Slack thread: https://fireworks-ai.slack.com/archives/C0AJY0JQVM1/p1776300586339259

## Test plan
- [x] Verified payload includes `prompt_cache_max_len: 0` when default is used
- [x] Verified payload includes `prompt_cache_max_len: N` when a non-zero value is specified


Made with [Cursor](https://cursor.com)