### PR TITLE
Expand prefill batch sizes

### DIFF
--- a/llm_bench/prefill_load_test.py
+++ b/llm_bench/prefill_load_test.py
@@ -72,8 +72,12 @@ def generate_pairs(max_seq_len: int, min_seq_len: int) -> list[tuple[int, int]]:
     s = min_seq_len
     while s <= max_seq_len:
         step = s // 8
-        for multiplier in [0, 1, 3, 5, 7]:
-            c = step * multiplier
+        cached_points = [step * multiplier for multiplier in [0, 1, 3, 5, 7]]
+        if step >= 4000:
+            cached_points.extend([step // 4, s - step // 4])
+        if step >= 16000:
+            cached_points.extend([step // 16, s - step // 16])
+        for c in sorted(set(cached_points)):
             if c <= s:
                 pairs.append((s, c))
         s *= 4


### PR DESCRIPTION
new default
```

(500, 0)
(500, 62)
(500, 186)
(500, 310)
(500, 434)
(2000, 0)
(2000, 250)
(2000, 750)
(2000, 1250)
(2000, 1750)
(8000, 0)
(8000, 1000)
(8000, 3000)
(8000, 5000)
(8000, 7000)
(32000, 0)
(32000, 1000)
(32000, 4000)
(32000, 12000)
(32000, 20000)
(32000, 28000)
(32000, 31000)
(128000, 0)
(128000, 1000)
(128000, 4000)
(128000, 16000)
(128000, 48000)
(128000, 80000)
(128000, 112000)
(128000, 124000)
(128000, 127000)
```