### PR TITLE
fix(llm_bench): gate prompt_cache_max_len on >0 to avoid extra_forbidden 400s

### DIFF
--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -903,7 +903,12 @@ class FireworksProvider(OpenAIProvider):
             data["min_tokens"] = max_tokens
         # Enable perf_metrics_in_response to get speculation stats in streaming responses
         data["perf_metrics_in_response"] = True
-        data["prompt_cache_max_len"] = self.parsed_options.prompt_cache_max_len
+        # Only send prompt_cache_max_len when the user explicitly opted in (>0). The
+        # default (0 = no caching) is a no-op for the server, but unconditionally
+        # adding the key breaks deployments whose OpenAI-compat schema is configured
+        # with extra="forbid" (e.g. some TRT-LLM and vLLM-style serving images).
+        if self.parsed_options.prompt_cache_max_len > 0:
+            data["prompt_cache_max_len"] = self.parsed_options.prompt_cache_max_len
         if self._acceptance_probs_override is not None:
             data["acceptance_probs_override"] = self._acceptance_probs_override
         if self._forced_generation_pool is not None:


### PR DESCRIPTION
## Problem

`FireworksProvider.format_payload` unconditionally adds `prompt_cache_max_len` to the request body:

```python
# llm_bench/load_test.py (before)
data["perf_metrics_in_response"] = True
data["prompt_cache_max_len"] = self.parsed_options.prompt_cache_max_len
```

The default for `--prompt-cache-max-len` is `0` (no caching), which is a no-op for the server semantically but still adds an unknown field to every request. Some Fireworks-hosted serving images now configure their OpenAI-compat request schema with pydantic `extra="forbid"`, so any unknown field 400s the request. We are seeing 100% request-level failure rate from firefresher load tests on TRT-LLM 4.221.0 and the Kimi-K2P5 vLLM-style image.

### Evidence: every request 400s

Two recent firefresher refresh runs failing identically — every request, no exceptions:

- [Customers run 24604168286](https://github.com/fw-ai/Customers/actions/runs/24604168286) (2026-04-18) — `accounts/zexia-31aa3b/deployments/tqyuq5dw`, Qwen 2.5-32B FP4, `TENSORRT_LLM`, source 4.166.0 → candidate 4.221.0. 18,763 / 18,763 HTTP 400.
- [Customers run 24642786227](https://github.com/fw-ai/Customers/actions/runs/24642786227) (2026-04-20) — `accounts/fireworks/deployments/gss27niu`, Kimi-K2P5, `ENGINE_UNSPECIFIED`, source 4.84.0 → candidate 4.221.0. 14,697 / 14,697 HTTP 400.

Server response from both runs:

```
HTTP 400: {"object":"error","message":"[
  {'type': 'extra_forbidden',
   'loc': ('body', 'prompt_cache_max_len'),
   'msg': 'Extra inputs are not permitted',
   'input': 0},
  {'type': 'extra_forbidden',
   'loc': ('body', 'raw_output'),
   'msg': 'Extra inputs are not permitted',
   'input': True}]","type":"BadRequestError","param":null,"code":400}
```

The `raw_output` half came from a vendored copy of this file inside the `Customers` repo and was already fixed by deleting that vendored copy in `fw-ai/Customers@2263e973` (2026-04-20). New runs use this submodule, where the only remaining unknown field on the wire is `prompt_cache_max_len`.

Note that pydantic returned all unknown fields at once. `perf_metrics_in_response`, the conditional `acceptance_probs_override`, and `forced_generation` were not flagged, so the strict schema does accept them — only `prompt_cache_max_len` needs to be gated.

### Why prior PRs did not fix this

[#62](https://github.com/fw-ai/benchmark/pull/62) edited `VllmProvider`, not `FireworksProvider`. Firefresher invokes Locust with `--provider fireworks`, so its requests go through `FireworksProvider.format_payload`, which #62 left untouched.

## Fix

One-line gate: only send `prompt_cache_max_len` when the user explicitly opted in (`> 0`). Default callers (firefresher always passes `--prompt-cache-max-len 0`, see [`deployment_refresh_activities.go:3546`](https://github.com/fw-ai/fireworks/blob/main/control_plane/pkg/lroworker/activities/deployment_refresh_activities.go#L3546)) stop including the field; explicit users keep their existing behavior.

```diff
         # Enable perf_metrics_in_response to get speculation stats in streaming responses
         data["perf_metrics_in_response"] = True
-        data["prompt_cache_max_len"] = self.parsed_options.prompt_cache_max_len
+        # Only send prompt_cache_max_len when the user explicitly opted in (>0). The
+        # default (0 = no caching) is a no-op for the server, but unconditionally
+        # adding the key breaks deployments whose OpenAI-compat schema is configured
+        # with extra="forbid" (e.g. some TRT-LLM and vLLM-style serving images).
+        if self.parsed_options.prompt_cache_max_len > 0:
+            data["prompt_cache_max_len"] = self.parsed_options.prompt_cache_max_len
```

## Behavior matrix

| Caller | Flag value | Before | After |
|---|---|---|---|
| firefresher / `Customers/load_test.yml` default | `0` | sends `prompt_cache_max_len: 0` → 400 on strict images | omits field → 200 |
| explicit cache test | e.g. `1024` | sends `prompt_cache_max_len: 1024` | sends `prompt_cache_max_len: 1024` (unchanged) |
| `--rerank` / `--embeddings` paths | n/a | early-return before this line | early-return before this line (unchanged) |

## Diagram

```mermaid
flowchart LR
    A[Locust task] --> B[FireworksProvider.format_payload]
    B --> C{prompt_cache_max_len > 0?}
    C -- yes --> D["body['prompt_cache_max_len'] = N"]
    C -- no --> E[skip field]
    D --> F[POST /v1/completions]
    E --> F
    F --> G[Strict-schema server accepts default request]
```

## Test plan

- [ ] Re-run firefresher refresh on `accounts/zexia-31aa3b/deployments/tqyuq5dw` (TRT-LLM 4.166.0 → 4.221.0) after `Customers` bumps the submodule pin — expect 200s and a real latency report.
- [ ] Re-run firefresher refresh on `accounts/fireworks/deployments/gss27niu` (Kimi-K2P5 4.84.0 → 4.221.0) — expect 200s.
- [ ] Spot-check an explicit prompt-cache run: `locust ... --prompt-cache-max-len 1024 ... --provider fireworks` against any deployment that supports `prompt_cache_max_len` and verify the field still appears in request bodies (use `--show-response` to confirm).

Made with [Cursor](https://cursor.com)