### PR TITLE
Split prompt prefix length from server prompt cache hint

### DIFF
--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -1916,7 +1916,8 @@ def init_parser(parser):
         env_var="PROMPT_CACHE_MAX_LEN",
         type=int,
         default=None,
-        help="Fireworks prompt_cache_max_len request field. If omitted, defaults to --prompt-prefix-len.",
+        help="Fireworks prompt_cache_max_len request field, specifically only taking effect for FA. "
+        "If omitted or <= 0, the field is not sent.",
     )
     parser.add_argument(
         "--prompt-prefix-len",

--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -903,12 +903,6 @@ class FireworksProvider(OpenAIProvider):
             data["min_tokens"] = max_tokens
         # Enable perf_metrics_in_response to get speculation stats in streaming responses
         data["perf_metrics_in_response"] = True
-        # Only send prompt_cache_max_len when the user explicitly opted in (>0). The
-        # default (0 = no caching) is a no-op for the server, but unconditionally
-        # adding the key breaks deployments whose OpenAI-compat schema is configured
-        # with extra="forbid" (e.g. some TRT-LLM and vLLM-style serving images).
-        if self.parsed_options.prompt_cache_max_len > 0:
-            data["prompt_cache_max_len"] = self.parsed_options.prompt_cache_max_len
         if self._acceptance_probs_override is not None:
             data["acceptance_probs_override"] = self._acceptance_probs_override
         if self._forced_generation_pool is not None:

--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -218,7 +218,7 @@ class DatasetHolder:
                     prompt = options.prompt
                 dataset_file = "code.txt"
 
-            common_tokens = options.prompt_cache_max_len
+            common_tokens = options.prompt_prefix_len
             if common_tokens > options.prompt_tokens:
                 common_tokens = options.prompt_tokens
             return TranslationDataset(
@@ -903,6 +903,10 @@ class FireworksProvider(OpenAIProvider):
             data["min_tokens"] = max_tokens
         # Enable perf_metrics_in_response to get speculation stats in streaming responses
         data["perf_metrics_in_response"] = True
+        prompt_cache_max_len = self.parsed_options.prompt_cache_max_len
+        if prompt_cache_max_len is None:
+            prompt_cache_max_len = self.parsed_options.prompt_prefix_len
+        data["prompt_cache_max_len"] = prompt_cache_max_len
         if self._acceptance_probs_override is not None:
             data["acceptance_probs_override"] = self._acceptance_probs_override
         if self._forced_generation_pool is not None:
@@ -1908,8 +1912,15 @@ def init_parser(parser):
         "--prompt-cache-max-len",
         env_var="PROMPT_CACHE_MAX_LEN",
         type=int,
+        default=None,
+        help="Fireworks prompt_cache_max_len request field. If omitted, defaults to --prompt-prefix-len.",
+    )
+    parser.add_argument(
+        "--prompt-prefix-len",
+        env_var="PROMPT_PREFIX_LEN",
+        type=int,
         default=0,
-        help="Maximum length of the prompt cache to use. Defaults to 0 (no caching).",
+        help="Target shared-prefix token length for synthetic datasets. Defaults to 0.",
     )
     parser.add_argument(
         "--acceptance-probs-override",

--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -904,9 +904,12 @@ class FireworksProvider(OpenAIProvider):
         # Enable perf_metrics_in_response to get speculation stats in streaming responses
         data["perf_metrics_in_response"] = True
         prompt_cache_max_len = self.parsed_options.prompt_cache_max_len
-        if prompt_cache_max_len is None:
-            prompt_cache_max_len = self.parsed_options.prompt_prefix_len
-        data["prompt_cache_max_len"] = prompt_cache_max_len
+        # Only send prompt_cache_max_len when the user explicitly opted in (>0). The
+        # default (0 = no caching) is a no-op for the server, but unconditionally
+        # adding the key breaks deployments whose OpenAI-compat schema is configured
+        # with extra="forbid" (e.g. some TRT-LLM and vLLM-style serving images).
+        if prompt_cache_max_len and prompt_cache_max_len > 0:
+            data["prompt_cache_max_len"] = prompt_cache_max_len
         if self._acceptance_probs_override is not None:
             data["acceptance_probs_override"] = self._acceptance_probs_override
         if self._forced_generation_pool is not None:


### PR DESCRIPTION
## Summary

*   Splits dataset prefix construction from the server prompt-cache hint so decode benchmarks don’t accidentally include extra prefill work.

*   Adds --prompt-prefix-len for synthetic dataset shared prefixes and keeps -pcml/--prompt-cache-max-len only for the payload field when explicitly set.

  ## Changes
  Introduce `--prompt-prefix-len` for dataset construction specifically.  Keep `-pcml` / `--prompt-cache-max-len` for the request payload. The payload field is only sent when `prompt_cache_max_len > 0`, so deployments with strict OpenAI-compatible schemas do not receive an extra  unsupported field by default.

 ## Background
  `prompt_cache_max_len` was being used for two different purposes: https://github.com/fw-ai/benchmark/pull/82
  1. Controlling synthetic dataset construction by deciding how much shared prefix to generate.
  2. Sending `prompt_cache_max_len` in the request payload as a server-side prompt cache hint. Those two meanings are not equivalent. The dataset builder creates a shared prefix by appending whole text chunks, so the requested prefix length is only a target and may not match the exact number of shared  input tokens.


  For example, with `prompt_cache_max_len=50000`, the generated input may end up with `50217` prompt tokens because the dataset builder appends whole chunks. If the payload still sends `"prompt_cache_max_len":  50000`, the server sees a cache hint that does not exactly match the generated prompt shape. For decode benchmarks, that can change prefill/cache behavior and distort the workload being measured, making decode performance look different from the intended setup.

