### PR TITLE
Extend generator and profiler load tests to use generator routing

### DIFF
--- a/llm_bench/gen_load_test.py
+++ b/llm_bench/gen_load_test.py
@@ -44,11 +44,9 @@ class RoutingConfig:
     """Generator-worker routing knobs for the benchmark client.
 
     `num_servers` and `num_local` define the round-robin space across
-    (service-index, local-index) cells. Either dimension can be pinned to a
-    specific value via `pin_server` / `pin_local_index`.
-
-    Routing headers are only emitted when at least one knob is non-default;
-    otherwise existing benchmark runs are unchanged byte-for-byte.
+    (service-index, local-index) cells. Routing headers are only emitted
+    when at least one dimension is greater than 1; otherwise existing
+    benchmark runs are unchanged byte-for-byte.
 
     Requires `enableGeneratorWorkerTargeting=true` on the deployment for the
     headers to take effect; otherwise they are ignored by Envoy.
@@ -56,27 +54,14 @@ class RoutingConfig:
 
     num_servers: int = 1
     num_local: int = 1
-    pin_server: Optional[int] = None
-    pin_local_index: Optional[int] = None
 
     @property
     def enabled(self) -> bool:
-        return (
-            self.num_servers > 1
-            or self.num_local > 1
-            or self.pin_server is not None
-            or self.pin_local_index is not None
-        )
+        return self.num_servers > 1 or self.num_local > 1
 
     def describe(self) -> str:
         if not self.enabled:
             return "off"
-        if self.pin_server is not None and self.pin_local_index is not None:
-            return f"pinned (s={self.pin_server},l={self.pin_local_index})"
-        if self.pin_server is not None:
-            return f"pinned-server s={self.pin_server} x {self.num_local} locals"
-        if self.pin_local_index is not None:
-            return f"{self.num_servers} servers x pinned-local l={self.pin_local_index}"
         return f"server-first {self.num_servers}x{self.num_local}"
 
 
@@ -92,8 +77,8 @@ def routing_headers_for_slot(cfg: Optional[RoutingConfig], slot_idx: int) -> dic
         return {}
     total = cfg.num_servers * cfg.num_local
     flat = slot_idx % total
-    server = cfg.pin_server if cfg.pin_server is not None else flat % cfg.num_servers
-    local = cfg.pin_local_index if cfg.pin_local_index is not None else flat // cfg.num_servers
+    server = flat % cfg.num_servers
+    local = flat // cfg.num_servers
     return {_SERVICE_INDEX_HEADER: str(server), _LOCAL_INDEX_HEADER: str(local)}
 
 
@@ -412,26 +397,14 @@ def _run_pair_n_mode(
     seq_len: int,
     batch_size: int,
     temperature: Optional[float],
-    routing: Optional[RoutingConfig] = None,
 ) -> GenBenchmarkResult:
     """Single request with n=batch_size."""
-    # n>1 mode runs the whole batch on one generator, so distribution across
-    # servers/locals is not meaningful here. We only attach routing headers
-    # when the caller has explicitly pinned both dimensions; otherwise we let
-    # the existing LB pick a generator.
-    pin_headers: dict[str, str] = {}
-    if routing is not None and routing.pin_server is not None and routing.pin_local_index is not None:
-        pin_headers = {
-            _SERVICE_INDEX_HEADER: str(routing.pin_server),
-            _LOCAL_INDEX_HEADER: str(routing.pin_local_index),
-        }
     logger.info(
-        "Pair (seq_len=%d, batch_size=%d): n=%d, max_tokens=%d, routing=%s",
+        "Pair (seq_len=%d, batch_size=%d): n=%d, max_tokens=%d",
         seq_len,
         batch_size,
         batch_size,
         max_tokens,
-        f"pinned (s={routing.pin_server},l={routing.pin_local_index})" if pin_headers else "off",
     )
 
     wall_start = time.perf_counter()
@@ -444,7 +417,6 @@ def _run_pair_n_mode(
         max_tokens=max_tokens,
         n=batch_size,
         temperature=temperature,
-        extra_headers=pin_headers or None,
     )
     wall = time.perf_counter() - wall_start
 
@@ -789,7 +761,6 @@ def run_benchmark(
                         seq_len=seq_len,
                         batch_size=batch_size,
                         temperature=temperature,
-                        routing=routing,
                     )
                 results.append(result)
                 break
@@ -961,20 +932,6 @@ def main() -> None:
         "round-robin range for x-fireworks-generator-worker-local-index. "
         "Default: 1.",
     )
-    parser.add_argument(
-        "--pin-server",
-        type=int,
-        default=None,
-        help="Pin all requests to this service-index instead of round-robining. "
-        "Must be in [0, --num-servers).",
-    )
-    parser.add_argument(
-        "--pin-local-index",
-        type=int,
-        default=None,
-        help="Pin all requests to this local-index instead of round-robining. "
-        "Must be in [0, --num-generators-per-server).",
-    )
 
     args = parser.parse_args()
 
@@ -982,15 +939,9 @@ def main() -> None:
         parser.error("--num-servers must be >= 1")
     if args.num_generators_per_server < 1:
         parser.error("--num-generators-per-server must be >= 1")
-    if args.pin_server is not None and not (0 <= args.pin_server < args.num_servers):
-        parser.error(f"--pin-server must be in [0, {args.num_servers})")
-    if args.pin_local_index is not None and not (0 <= args.pin_local_index < args.num_generators_per_server):
-        parser.error(f"--pin-local-index must be in [0, {args.num_generators_per_server})")
     routing = RoutingConfig(
         num_servers=args.num_servers,
         num_local=args.num_generators_per_server,
-        pin_server=args.pin_server,
-        pin_local_index=args.pin_local_index,
     )
 
     if args.seq_batch_pairs is not None:

--- a/llm_bench/gen_load_test.py
+++ b/llm_bench/gen_load_test.py
@@ -624,7 +624,6 @@ def run_benchmark(
     pairs: list[tuple[int, int]],
     max_tokens: int,
     temperature: Optional[float] = None,
-    separate_requests: bool = False,
     retries: int = 3,
     retry_delay: float = 30.0,
     seed: int = 0,
@@ -643,11 +642,16 @@ def run_benchmark(
     url = completions_url(base_url)
     session = requests.Session()
 
+    # Mode is derived from routing: enabled (num_servers > 1 OR num_gens > 1)
+    # implies separate concurrent requests pinned to specific cells; disabled
+    # falls back to a single request with n=batch_size against the LB.
+    routing = routing or RoutingConfig()
+    separate_requests = routing.enabled
     if separate_requests:
         logger.info("Mode: separate concurrent requests (no n>1)")
     else:
         logger.info("Mode: single request with n=batch_size")
-    logger.info("Routing: %s", (routing or RoutingConfig()).describe())
+    logger.info("Routing: %s", routing.describe())
 
     results: list[GenBenchmarkResult] = []
     prev_seq_len: Optional[int] = None
@@ -891,17 +895,11 @@ def main() -> None:
         help="Sampling temperature (optional; omit to use server default).",
     )
     parser.add_argument(
-        "--separate-requests",
-        action="store_true",
-        default=False,
-        help="Send batch_size separate concurrent requests (each with n=1) "
-        "instead of a single request with n=batch_size. Useful for testing LLMs in data parallel mode.",
-    )
-    parser.add_argument(
         "--seed",
         type=int,
         default=0,
-        help="Seed for deterministic per-request `user` ids in --separate-requests mode. Default: 0.",
+        help="Seed for deterministic per-request `user` ids when routing is enabled "
+        "(--num-servers/--num-gens > 1). Default: 0.",
     )
     parser.add_argument(
         "--retries",
@@ -985,7 +983,6 @@ def main() -> None:
         pairs=pairs,
         max_tokens=args.max_tokens,
         temperature=args.temperature,
-        separate_requests=args.separate_requests,
         retries=args.retries,
         retry_delay=args.retry_delay,
         seed=args.seed,

--- a/llm_bench/gen_load_test.py
+++ b/llm_bench/gen_load_test.py
@@ -43,8 +43,8 @@ _LOCAL_INDEX_HEADER = "x-fireworks-generator-worker-local-index"
 class RoutingConfig:
     """Generator-worker routing knobs for the benchmark client.
 
-    `num_servers` and `num_local` define the round-robin space across
-    (service-index, local-index) cells. Routing headers are only emitted
+    `num_servers` and `num_gens` define the round-robin space across
+    (service-index, local-index) workers. Routing headers are only emitted
     when at least one dimension is greater than 1; otherwise existing
     benchmark runs are unchanged byte-for-byte.
 
@@ -53,30 +53,30 @@ class RoutingConfig:
     """
 
     num_servers: int = 1
-    num_local: int = 1
+    num_gens: int = 1
 
     @property
     def enabled(self) -> bool:
-        return self.num_servers > 1 or self.num_local > 1
+        return self.num_servers > 1 or self.num_gens > 1
 
     def describe(self) -> str:
         if not self.enabled:
             return "off"
-        return f"server-first {self.num_servers}x{self.num_local}"
+        return f"server-first {self.num_servers}x{self.num_gens}"
 
 
-def routing_headers_for_slot(cfg: Optional[RoutingConfig], slot_idx: int) -> dict[str, str]:
-    """Return the routing headers to attach to the request for the given slot.
+def routing_headers_for_worker(cfg: Optional[RoutingConfig], worker_idx: int) -> dict[str, str]:
+    """Return the routing headers to attach to the request for the given worker.
 
     Server-first cycling keeps the per-server distribution balanced even when
-    `batch_size < num_servers * num_local`: e.g. with 2 servers x 4 locals and
-    batch=4, cells visited are (s0,l0),(s1,l0),(s0,l1),(s1,l1) so each server
+    `batch_size < num_servers * num_gens`: e.g. with 2 servers x 4 locals and
+    batch=4, workers visited are (s0,l0),(s1,l0),(s0,l1),(s1,l1) so each server
     gets two requests rather than one server eating the whole batch.
     """
     if cfg is None or not cfg.enabled:
         return {}
-    total = cfg.num_servers * cfg.num_local
-    flat = slot_idx % total
+    total = cfg.num_servers * cfg.num_gens
+    flat = worker_idx % total
     server = flat % cfg.num_servers
     local = flat // cfg.num_servers
     return {_SERVICE_INDEX_HEADER: str(server), _LOCAL_INDEX_HEADER: str(local)}
@@ -470,7 +470,7 @@ def _run_pair_separate_mode(
     temperature: Optional[float],
     users: list[str],
     routing: Optional[RoutingConfig] = None,
-    slot_offset: int = 0,
+    worker_offset: int = 0,
 ) -> GenBenchmarkResult:
     """Send batch_size concurrent requests each with n=1."""
     logger.info(
@@ -483,12 +483,12 @@ def _run_pair_separate_mode(
     )
     assert len(users) == batch_size, f"expected {batch_size} users, got {len(users)}"
 
-    def _single_request(slot_idx: int, user: str) -> requests.Response:
+    def _single_request(worker_idx: int, user: str) -> requests.Response:
         s = requests.Session()
-        headers = routing_headers_for_slot(routing, slot_offset + slot_idx)
+        headers = routing_headers_for_worker(routing, worker_offset + worker_idx)
         if headers and logger.isEnabledFor(logging.DEBUG):
             logger.debug(
-                "  slot=%d server=%s local=%s", slot_idx, headers.get(_SERVICE_INDEX_HEADER), headers.get(_LOCAL_INDEX_HEADER)
+                "  worker=%d server=%s local=%s", worker_idx, headers.get(_SERVICE_INDEX_HEADER), headers.get(_LOCAL_INDEX_HEADER)
             )
         return post_completion(
             s,
@@ -562,14 +562,14 @@ def _warmup_seq_len(
     retry_delay: float,
     users: Optional[list[str]] = None,
     routing: Optional[RoutingConfig] = None,
-    slot_offset: int = 0,
+    worker_offset: int = 0,
 ) -> None:
     """Issue `concurrency` warmup completions in parallel for the same prompt."""
     if users is not None:
         assert len(users) == concurrency, f"expected {concurrency} users, got {len(users)}"
 
-    def _single(slot_idx: int, user: Optional[str]) -> requests.Response:
-        headers = routing_headers_for_slot(routing, slot_offset + slot_idx)
+    def _single(worker_idx: int, user: Optional[str]) -> requests.Response:
+        headers = routing_headers_for_worker(routing, worker_offset + worker_idx)
         return post_completion(
             requests.Session(),
             url,
@@ -678,8 +678,8 @@ def run_benchmark(
                     # across generators before the user-pinned warmup at full
                     # batch_size. TODO: fix the backend OOM and remove this.
                     #
-                    # When routing is enabled we also round-robin the slot
-                    # index across all (server, local) cells so every DP group
+                    # When routing is enabled we also round-robin the worker
+                    # index across all (server, local) workers so every DP group
                     # gets primed by this hack instead of relying on the LB.
                     logger.info(
                         "Pre-warmup (seq_len=%d): 64 sequential requests with random users (HACK)",
@@ -699,7 +699,7 @@ def run_benchmark(
                             retry_delay=retry_delay,
                             users=[str(rng.randint(0, 2**63 - 1))],
                             routing=routing,
-                            slot_offset=i,
+                            worker_offset=i,
                         )
                 seq_users = _generate_users(seq_len + seed, batch_size)
                 _warmup_seq_len(
@@ -716,7 +716,7 @@ def run_benchmark(
                     routing=routing,
                 )
             else:
-                # n-mode measurement is unrouted; warmup must match or cache primes the wrong cell.
+                # n-mode measurement is unrouted; warmup must match or cache primes the wrong worker.
                 _warmup_seq_len(
                     url=url,
                     api_key=api_key,
@@ -926,11 +926,13 @@ def main() -> None:
     )
     parser.add_argument(
         "--num-generators-per-server",
+        "--num-gens",
+        dest="num_generators_per_server",
         type=int,
         default=1,
         help="Number of data-parallel generator groups per server, used as the "
         "round-robin range for x-fireworks-generator-worker-local-index. "
-        "Default: 1.",
+        "Alias matches fw-infer's --num-gens. Default: 1.",
     )
 
     args = parser.parse_args()
@@ -941,7 +943,7 @@ def main() -> None:
         parser.error("--num-generators-per-server must be >= 1")
     routing = RoutingConfig(
         num_servers=args.num_servers,
-        num_local=args.num_generators_per_server,
+        num_gens=args.num_generators_per_server,
     )
 
     if args.seq_batch_pairs is not None:

--- a/llm_bench/gen_load_test.py
+++ b/llm_bench/gen_load_test.py
@@ -35,6 +35,68 @@ from tabulate import tabulate
 
 FW_HEADER_PREFIX = "fireworks-"
 
+_SERVICE_INDEX_HEADER = "x-fireworks-generator-worker-service-index"
+_LOCAL_INDEX_HEADER = "x-fireworks-generator-worker-local-index"
+
+
+@dataclass(frozen=True)
+class RoutingConfig:
+    """Generator-worker routing knobs for the benchmark client.
+
+    `num_servers` and `num_local` define the round-robin space across
+    (service-index, local-index) cells. Either dimension can be pinned to a
+    specific value via `pin_server` / `pin_local_index`.
+
+    Routing headers are only emitted when at least one knob is non-default;
+    otherwise existing benchmark runs are unchanged byte-for-byte.
+
+    Requires `enableGeneratorWorkerTargeting=true` on the deployment for the
+    headers to take effect; otherwise they are ignored by Envoy.
+    """
+
+    num_servers: int = 1
+    num_local: int = 1
+    pin_server: Optional[int] = None
+    pin_local_index: Optional[int] = None
+
+    @property
+    def enabled(self) -> bool:
+        return (
+            self.num_servers > 1
+            or self.num_local > 1
+            or self.pin_server is not None
+            or self.pin_local_index is not None
+        )
+
+    def describe(self) -> str:
+        if not self.enabled:
+            return "off"
+        if self.pin_server is not None and self.pin_local_index is not None:
+            return f"pinned (s={self.pin_server},l={self.pin_local_index})"
+        if self.pin_server is not None:
+            return f"pinned-server s={self.pin_server} x {self.num_local} locals"
+        if self.pin_local_index is not None:
+            return f"{self.num_servers} servers x pinned-local l={self.pin_local_index}"
+        return f"server-first {self.num_servers}x{self.num_local}"
+
+
+def routing_headers_for_slot(cfg: Optional[RoutingConfig], slot_idx: int) -> dict[str, str]:
+    """Return the routing headers to attach to the request for the given slot.
+
+    Server-first cycling keeps the per-server distribution balanced even when
+    `batch_size < num_servers * num_local`: e.g. with 2 servers x 4 locals and
+    batch=4, cells visited are (s0,l0),(s1,l0),(s0,l1),(s1,l1) so each server
+    gets two requests rather than one server eating the whole batch.
+    """
+    if cfg is None or not cfg.enabled:
+        return {}
+    total = cfg.num_servers * cfg.num_local
+    flat = slot_idx % total
+    server = cfg.pin_server if cfg.pin_server is not None else flat % cfg.num_servers
+    local = cfg.pin_local_index if cfg.pin_local_index is not None else flat // cfg.num_servers
+    return {_SERVICE_INDEX_HEADER: str(server), _LOCAL_INDEX_HEADER: str(local)}
+
+
 _FAST_BATCH_SIZES = [1, 2, 3, 4, 5, 6, 7, 8]
 
 # NB: don't use power of 2 as we will use multiples of this to generate seq pairs
@@ -293,6 +355,7 @@ def post_completion(
     n: int,
     temperature: Optional[float] = None,
     user: Optional[str] = None,
+    extra_headers: Optional[dict[str, str]] = None,
 ) -> requests.Response:
     payload: dict[str, Any] = {
         "prompt": prompt,
@@ -309,6 +372,8 @@ def post_completion(
     headers = {"Content-Type": "application/json"}
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
+    if extra_headers:
+        headers.update(extra_headers)
     return session.post(url, headers=headers, json=payload, timeout=3600)
 
 
@@ -347,14 +412,26 @@ def _run_pair_n_mode(
     seq_len: int,
     batch_size: int,
     temperature: Optional[float],
+    routing: Optional[RoutingConfig] = None,
 ) -> GenBenchmarkResult:
     """Single request with n=batch_size."""
+    # n>1 mode runs the whole batch on one generator, so distribution across
+    # servers/locals is not meaningful here. We only attach routing headers
+    # when the caller has explicitly pinned both dimensions; otherwise we let
+    # the existing LB pick a generator.
+    pin_headers: dict[str, str] = {}
+    if routing is not None and routing.pin_server is not None and routing.pin_local_index is not None:
+        pin_headers = {
+            _SERVICE_INDEX_HEADER: str(routing.pin_server),
+            _LOCAL_INDEX_HEADER: str(routing.pin_local_index),
+        }
     logger.info(
-        "Pair (seq_len=%d, batch_size=%d): n=%d, max_tokens=%d",
+        "Pair (seq_len=%d, batch_size=%d): n=%d, max_tokens=%d, routing=%s",
         seq_len,
         batch_size,
         batch_size,
         max_tokens,
+        f"pinned (s={routing.pin_server},l={routing.pin_local_index})" if pin_headers else "off",
     )
 
     wall_start = time.perf_counter()
@@ -367,6 +444,7 @@ def _run_pair_n_mode(
         max_tokens=max_tokens,
         n=batch_size,
         temperature=temperature,
+        extra_headers=pin_headers or None,
     )
     wall = time.perf_counter() - wall_start
 
@@ -419,19 +497,27 @@ def _run_pair_separate_mode(
     batch_size: int,
     temperature: Optional[float],
     users: list[str],
+    routing: Optional[RoutingConfig] = None,
+    slot_offset: int = 0,
 ) -> GenBenchmarkResult:
     """Send batch_size concurrent requests each with n=1."""
     logger.info(
-        "Pair (seq_len=%d, batch_size=%d): %d separate requests, max_tokens=%d",
+        "Pair (seq_len=%d, batch_size=%d): %d separate requests, max_tokens=%d, routing=%s",
         seq_len,
         batch_size,
         batch_size,
         max_tokens,
+        (routing or RoutingConfig()).describe(),
     )
     assert len(users) == batch_size, f"expected {batch_size} users, got {len(users)}"
 
-    def _single_request(user: str) -> requests.Response:
+    def _single_request(slot_idx: int, user: str) -> requests.Response:
         s = requests.Session()
+        headers = routing_headers_for_slot(routing, slot_offset + slot_idx)
+        if headers and logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "  slot=%d server=%s local=%s", slot_idx, headers.get(_SERVICE_INDEX_HEADER), headers.get(_LOCAL_INDEX_HEADER)
+            )
         return post_completion(
             s,
             url,
@@ -442,11 +528,12 @@ def _run_pair_separate_mode(
             n=1,
             temperature=temperature,
             user=user,
+            extra_headers=headers or None,
         )
 
     wall_start = time.perf_counter()
     with ThreadPoolExecutor(max_workers=batch_size) as pool:
-        futures = [pool.submit(_single_request, u) for u in users]
+        futures = [pool.submit(_single_request, i, u) for i, u in enumerate(users)]
         responses = []
         for fut in as_completed(futures):
             responses.append(fut.result())
@@ -502,12 +589,15 @@ def _warmup_seq_len(
     retries: int,
     retry_delay: float,
     users: Optional[list[str]] = None,
+    routing: Optional[RoutingConfig] = None,
+    slot_offset: int = 0,
 ) -> None:
     """Issue `concurrency` warmup completions in parallel for the same prompt."""
     if users is not None:
         assert len(users) == concurrency, f"expected {concurrency} users, got {len(users)}"
 
-    def _single(user: Optional[str]) -> requests.Response:
+    def _single(slot_idx: int, user: Optional[str]) -> requests.Response:
+        headers = routing_headers_for_slot(routing, slot_offset + slot_idx)
         return post_completion(
             requests.Session(),
             url,
@@ -518,6 +608,7 @@ def _warmup_seq_len(
             n=1,
             temperature=temperature,
             user=user,
+            extra_headers=headers or None,
         )
 
     for attempt in range(1, retries + 1):
@@ -530,10 +621,10 @@ def _warmup_seq_len(
         )
         request_users: list[Optional[str]] = list(users) if users is not None else [None] * concurrency
         if concurrency == 1:
-            responses = [_single(request_users[0])]
+            responses = [_single(0, request_users[0])]
         else:
             with ThreadPoolExecutor(max_workers=concurrency) as pool:
-                futures = [pool.submit(_single, u) for u in request_users]
+                futures = [pool.submit(_single, i, u) for i, u in enumerate(request_users)]
                 responses = [f.result() for f in as_completed(futures)]
 
         bad = next((r for r in responses if r.status_code != 200), None)
@@ -565,6 +656,7 @@ def run_benchmark(
     retries: int = 3,
     retry_delay: float = 30.0,
     seed: int = 0,
+    routing: Optional[RoutingConfig] = None,
 ) -> list[GenBenchmarkResult]:
     tokenizer = _load_auto_tokenizer(tokenizer_path)
     model_type = resolve_model_type(tokenizer_path)
@@ -583,6 +675,7 @@ def run_benchmark(
         logger.info("Mode: separate concurrent requests (no n>1)")
     else:
         logger.info("Mode: single request with n=batch_size")
+    logger.info("Routing: %s", (routing or RoutingConfig()).describe())
 
     results: list[GenBenchmarkResult] = []
     prev_seq_len: Optional[int] = None
@@ -612,12 +705,16 @@ def run_benchmark(
                     # with a fresh random `user` each time primes the backend
                     # across generators before the user-pinned warmup at full
                     # batch_size. TODO: fix the backend OOM and remove this.
+                    #
+                    # When routing is enabled we also round-robin the slot
+                    # index across all (server, local) cells so every DP group
+                    # gets primed by this hack instead of relying on the LB.
                     logger.info(
                         "Pre-warmup (seq_len=%d): 64 sequential requests with random users (HACK)",
                         seq_len,
                     )
                     rng = random.Random(seed)
-                    for _ in range(64):
+                    for i in range(64):
                         _warmup_seq_len(
                             url=url,
                             api_key=api_key,
@@ -629,6 +726,8 @@ def run_benchmark(
                             retries=retries,
                             retry_delay=retry_delay,
                             users=[str(rng.randint(0, 2**63 - 1))],
+                            routing=routing,
+                            slot_offset=i,
                         )
                 seq_users = _generate_users(seq_len + seed, batch_size)
                 _warmup_seq_len(
@@ -642,6 +741,7 @@ def run_benchmark(
                     retries=retries,
                     retry_delay=retry_delay,
                     users=seq_users,
+                    routing=routing,
                 )
             else:
                 _warmup_seq_len(
@@ -654,6 +754,7 @@ def run_benchmark(
                     temperature=temperature,
                     retries=retries,
                     retry_delay=retry_delay,
+                    routing=routing,
                 )
             prev_seq_len = seq_len
 
@@ -675,6 +776,7 @@ def run_benchmark(
                         batch_size=batch_size,
                         temperature=temperature,
                         users=users,
+                        routing=routing,
                     )
                 else:
                     result = _run_pair_n_mode(
@@ -687,6 +789,7 @@ def run_benchmark(
                         seq_len=seq_len,
                         batch_size=batch_size,
                         temperature=temperature,
+                        routing=routing,
                     )
                 results.append(result)
                 break
@@ -841,8 +944,54 @@ def main() -> None:
         default=30.0,
         help="Seconds to sleep between retries (default: 30).",
     )
+    parser.add_argument(
+        "--num-servers",
+        type=int,
+        default=1,
+        help="Number of generator servers to fan requests out across via "
+        "x-fireworks-generator-worker-service-index. Requires the deployment to "
+        "be rendered with enableGeneratorWorkerTargeting=true; otherwise the "
+        "header is ignored. Default: 1 (no service-index header sent).",
+    )
+    parser.add_argument(
+        "--num-generators-per-server",
+        type=int,
+        default=1,
+        help="Number of data-parallel generator groups per server, used as the "
+        "round-robin range for x-fireworks-generator-worker-local-index. "
+        "Default: 1.",
+    )
+    parser.add_argument(
+        "--pin-server",
+        type=int,
+        default=None,
+        help="Pin all requests to this service-index instead of round-robining. "
+        "Must be in [0, --num-servers).",
+    )
+    parser.add_argument(
+        "--pin-local-index",
+        type=int,
+        default=None,
+        help="Pin all requests to this local-index instead of round-robining. "
+        "Must be in [0, --num-generators-per-server).",
+    )
 
     args = parser.parse_args()
+
+    if args.num_servers < 1:
+        parser.error("--num-servers must be >= 1")
+    if args.num_generators_per_server < 1:
+        parser.error("--num-generators-per-server must be >= 1")
+    if args.pin_server is not None and not (0 <= args.pin_server < args.num_servers):
+        parser.error(f"--pin-server must be in [0, {args.num_servers})")
+    if args.pin_local_index is not None and not (0 <= args.pin_local_index < args.num_generators_per_server):
+        parser.error(f"--pin-local-index must be in [0, {args.num_generators_per_server})")
+    routing = RoutingConfig(
+        num_servers=args.num_servers,
+        num_local=args.num_generators_per_server,
+        pin_server=args.pin_server,
+        pin_local_index=args.pin_local_index,
+    )
 
     if args.seq_batch_pairs is not None:
         pairs = parse_pairs_arg(args.seq_batch_pairs)
@@ -887,6 +1036,7 @@ def main() -> None:
         retries=args.retries,
         retry_delay=args.retry_delay,
         seed=args.seed,
+        routing=routing,
     )
     if args.format == "csv":
         print(format_csv(rows))

--- a/llm_bench/gen_load_test.py
+++ b/llm_bench/gen_load_test.py
@@ -716,6 +716,7 @@ def run_benchmark(
                     routing=routing,
                 )
             else:
+                # n-mode measurement is unrouted; warmup must match or cache primes the wrong cell.
                 _warmup_seq_len(
                     url=url,
                     api_key=api_key,
@@ -726,7 +727,6 @@ def run_benchmark(
                     temperature=temperature,
                     retries=retries,
                     retry_delay=retry_delay,
-                    routing=routing,
                 )
             prev_seq_len = seq_len
 

--- a/llm_bench/prefill_load_test.py
+++ b/llm_bench/prefill_load_test.py
@@ -23,6 +23,7 @@ import random
 import sys
 import time
 from collections.abc import Mapping
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import Any, Optional
@@ -43,6 +44,58 @@ STAGE_HEADER_KEYS = (
     "prefill-duration",
     "generation-queue-duration",
 )
+
+_SERVICE_INDEX_HEADER = "x-fireworks-generator-worker-service-index"
+_LOCAL_INDEX_HEADER = "x-fireworks-generator-worker-local-index"
+
+
+@dataclass(frozen=True)
+class RoutingConfig:
+    """Generator-worker routing knobs for the benchmark client.
+
+    `num_servers` and `num_local` define the round-robin space across
+    (service-index, local-index) cells. When at least one dimension is greater
+    than 1, each pair's `batch_size` prompts are split round-robin across
+    `num_servers * num_local` cells (one multi-prompt HTTP request per cell,
+    all firing concurrently). Per-cell load is `batch_size / total_cells` prompts;
+    total deployment-level load matches the no-routing baseline.
+
+    Inline (non-disagg) deployments only: in tiered-disagg this only pins the
+    generator side, not the prefiller. Requires `enableGeneratorWorkerTargeting=true`
+    on the deployment for the headers to take effect.
+    """
+
+    num_servers: int = 1
+    num_local: int = 1
+
+    @property
+    def enabled(self) -> bool:
+        return self.num_servers > 1 or self.num_local > 1
+
+    @property
+    def total_cells(self) -> int:
+        return self.num_servers * self.num_local
+
+    def describe(self) -> str:
+        if not self.enabled:
+            return "off"
+        return f"server-first {self.num_servers}x{self.num_local}"
+
+
+def routing_headers_for_slot(cfg: Optional[RoutingConfig], slot_idx: int) -> dict[str, str]:
+    """Return the routing headers to attach to the request for the given slot.
+
+    Server-first cycling: with 2 servers x 4 locals and slot=2,4,6 the cells
+    visited are (s0,l1),(s0,l2),(s0,l3) so the per-server distribution stays
+    balanced even at small slot counts.
+    """
+    if cfg is None or not cfg.enabled:
+        return {}
+    total = cfg.num_servers * cfg.num_local
+    flat = slot_idx % total
+    server = flat % cfg.num_servers
+    local = flat // cfg.num_servers
+    return {_SERVICE_INDEX_HEADER: str(server), _LOCAL_INDEX_HEADER: str(local)}
 
 # NB: don't use power of 2 as we will use multiples of this to generate seq pairs
 # and in some cases it will batch max seq len of a model, which is the edge case we don't want to benchmark.
@@ -347,6 +400,128 @@ class PairBenchmarkResult:
     mean_fireworks_cached_prompt_tokens: Optional[float]
 
 
+def _send_and_parse_measurement(
+    *,
+    session: requests.Session,
+    url: str,
+    api_key: str,
+    model: Optional[str],
+    prompt_token_ids: list[list[int]],
+    max_tokens: int,
+    cached_tokens: int,
+    extra_headers: Optional[dict[str, str]] = None,
+) -> tuple[float, float, Optional[int], Optional[int]]:
+    """Send one multi-prompt prefill request, return (server_duration, client_duration, fwp, fwc).
+
+    Raises RuntimeError on non-200 or missing Fireworks timing headers.
+    """
+    wall_start = time.perf_counter()
+    r = post_completion(
+        session,
+        url,
+        api_key,
+        model,
+        prompt_token_ids,
+        max_tokens,
+        prompt_cache_max_len=cached_tokens,
+        extra_headers=extra_headers,
+    )
+    wall = time.perf_counter() - wall_start
+
+    if r.status_code != 200:
+        raise RuntimeError(f"Request failed HTTP {r.status_code}: {r.text[:500]}")
+
+    fwp = get_int_header(r.headers, "prompt-tokens")
+    fwc = get_int_header(r.headers, "cached-prompt-tokens")
+    server_processing = get_header(r.headers, "server-processing-time")
+    st = server_processing if server_processing is not None else sum_stage_seconds(r.headers)
+    if st is None:
+        raise RuntimeError(
+            "Missing Fireworks timing headers (need dedicated deployment?). "
+            f"Got keys: {list(r.headers.keys())[:30]}"
+        )
+    return st, wall, fwp, fwc
+
+
+def _measure_pair_split_across_cells(
+    *,
+    routing: RoutingConfig,
+    url: str,
+    api_key: str,
+    model: Optional[str],
+    prompt_token_ids: list[list[int]],
+    max_tokens: int,
+    cached_tokens: int,
+) -> tuple[float, float, Optional[int], Optional[int]]:
+    """Split the multi-prompt batch across cells, fire one chunk per cell concurrently.
+
+    Stride-slices `prompt_token_ids` into routing.total_cells chunks
+    (prompts[i::total_cells]) so each cell processes ~batch_size/total_cells prompts
+    in its own multi-prompt request. Total deployment-level work matches the
+    no-routing baseline; per-cell pressure is divided across cells. When
+    batch_size < total_cells, some chunks are empty and those cells are skipped.
+
+    Reports max(server_duration), max(client_duration) across cells (latency
+    bottlenecked by slowest cell). Token counts are summed across cells (each
+    cell processed a distinct slice).
+    """
+    total_cells = routing.total_cells
+    # Stride-slice for even round-robin distribution. Uneven splits handled
+    # naturally (e.g. 1985 / 4 -> [497, 496, 496, 496]).
+    chunks: list[list[list[int]]] = [
+        prompt_token_ids[i::total_cells] for i in range(total_cells)
+    ]
+    active_slots = [i for i, c in enumerate(chunks) if c]
+
+    def _run_slot(slot_idx: int) -> tuple[int, float, float, Optional[int], Optional[int]]:
+        # Distinct session per cell to avoid HTTP/2 multiplexing bias on a shared session.
+        s = requests.Session()
+        try:
+            headers = routing_headers_for_slot(routing, slot_idx)
+            st, wall, fwp, fwc = _send_and_parse_measurement(
+                session=s,
+                url=url,
+                api_key=api_key,
+                model=model,
+                prompt_token_ids=chunks[slot_idx],
+                max_tokens=max_tokens,
+                cached_tokens=cached_tokens,
+                extra_headers=headers,
+            )
+            return slot_idx, st, wall, fwp, fwc
+        finally:
+            s.close()
+
+    with ThreadPoolExecutor(max_workers=len(active_slots)) as pool:
+        futures = [pool.submit(_run_slot, i) for i in active_slots]
+        per_cell = [fut.result() for fut in as_completed(futures)]
+
+    per_cell.sort(key=lambda r: r[0])
+    if logger.isEnabledFor(logging.DEBUG):
+        for slot_idx, st, wall, fwp, fwc in per_cell:
+            logger.debug(
+                "  cell=%d chunk=%d server-duration=%.6fs client=%.2fs fwp=%s fwc=%s",
+                slot_idx,
+                len(chunks[slot_idx]),
+                st,
+                wall,
+                fwp,
+                fwc,
+            )
+
+    server_durations = [row[1] for row in per_cell]
+    client_durations = [row[2] for row in per_cell]
+    fwps = [row[3] for row in per_cell if row[3] is not None]
+    fwcs = [row[4] for row in per_cell if row[4] is not None]
+    # max() for latency: server is bottlenecked by the slowest cell.
+    # sum() for token counts: each cell processed its own slice; sum reconstructs
+    # the deployment-level total for cross-checking against expected
+    # batch_size * prompt_tokens / batch_size * cached_tokens.
+    fwp_agg = sum(fwps) if fwps else None
+    fwc_agg = sum(fwcs) if fwcs else None
+    return max(server_durations), max(client_durations), fwp_agg, fwc_agg
+
+
 def post_completion(
     session: requests.Session,
     url: str,
@@ -355,6 +530,7 @@ def post_completion(
     prompt: str | list[str] | list[int] | list[list[int]],
     max_tokens: int,
     prompt_cache_max_len: int | None = None,
+    extra_headers: Optional[dict[str, str]] = None,
 ) -> requests.Response:
     payload: dict[str, Any] = {
         "prompt": prompt,
@@ -370,6 +546,8 @@ def post_completion(
     headers = {"Content-Type": "application/json"}
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
+    if extra_headers:
+        headers.update(extra_headers)
     return session.post(url, headers=headers, json=payload, timeout=3600)
 
 
@@ -385,8 +563,10 @@ def run_benchmark(
     rng_seed: Optional[int],
     retries: int = 3,
     retry_delay: float = 30.0,
+    routing: Optional[RoutingConfig] = None,
 ) -> list[PairBenchmarkResult]:
     """Per-pair prefill benchmark with multi-prompt batching."""
+    routing = routing or RoutingConfig()
     tokenizer = _load_auto_tokenizer(tokenizer_path)
     model_type = resolve_model_type(tokenizer_path)
     if model_type == "deepseek_v4":
@@ -402,6 +582,7 @@ def run_benchmark(
         len(chat_suffix_ids),
         chat_overhead,
     )
+    logger.info("Routing: %s", routing.describe())
 
     base_ids = build_ids_to_length(tokenizer, chunks, max_seq)
     if len(base_ids) != max_seq:
@@ -410,9 +591,11 @@ def run_benchmark(
     url = completions_url(base_url)
     session = requests.Session()
 
-    def do_warmup(cached_tokens: int) -> None:
+    def do_warmup(cached_tokens: int, extra_headers: Optional[dict[str, str]] = None) -> None:
         warmup_ids = build_warmup_ids(chat_prefix_ids, base_ids, cached_tokens)
-        w = post_completion(session, url, api_key, model, warmup_ids, max_tokens)
+        w = post_completion(
+            session, url, api_key, model, warmup_ids, max_tokens, extra_headers=extra_headers
+        )
         if w.status_code != 200:
             raise RuntimeError(f"Warmup failed HTTP {w.status_code}: {w.text[:500]}")
 
@@ -430,8 +613,18 @@ def run_benchmark(
 
         for attempt in range(1, retries + 1):
             try:
+                # Warmup: prime cache on every cell we're about to measure. In
+                # routing mode, each cell needs its own warmup or the
+                # measurement on that cell will see a cache miss.
                 if cached_tokens > 0:
-                    do_warmup(cached_tokens)
+                    if routing.enabled:
+                        for slot_idx in range(routing.total_cells):
+                            do_warmup(
+                                cached_tokens,
+                                extra_headers=routing_headers_for_slot(routing, slot_idx),
+                            )
+                    else:
+                        do_warmup(cached_tokens)
 
                 prompt_token_ids: list[list[int]] = []
                 uncached_tokens = prompt_tokens - cached_tokens
@@ -452,28 +645,32 @@ def run_benchmark(
                     prompt_token_ids.append(pair_ids)
 
                 logger.info(
-                    "Pair (%d, %d): sending %d prompts in one request",
+                    "Pair (%d, %d): sending %d prompts in one request, routing=%s",
                     prompt_tokens,
                     cached_tokens,
                     len(prompt_token_ids),
+                    routing.describe(),
                 )
-                wall_start = time.perf_counter()
-                r = post_completion(
-                    session, url, api_key, model, prompt_token_ids, max_tokens, prompt_cache_max_len=cached_tokens
-                )
-                if r.status_code != 200:
-                    raise RuntimeError(f"Request failed HTTP {r.status_code}: {r.text[:500]}")
-                wall = time.perf_counter() - wall_start
 
-                fwp = get_int_header(r.headers, "prompt-tokens")
-                fwc = get_int_header(r.headers, "cached-prompt-tokens")
-
-                server_processing = get_header(r.headers, "server-processing-time")
-                st = server_processing if server_processing is not None else sum_stage_seconds(r.headers)
-                if st is None:
-                    raise RuntimeError(
-                        "Missing Fireworks timing headers (need dedicated deployment?). "
-                        f"Got keys: {list(r.headers.keys())[:30]}"
+                if routing.enabled:
+                    st, wall, fwp, fwc = _measure_pair_split_across_cells(
+                        routing=routing,
+                        url=url,
+                        api_key=api_key,
+                        model=model,
+                        prompt_token_ids=prompt_token_ids,
+                        max_tokens=max_tokens,
+                        cached_tokens=cached_tokens,
+                    )
+                else:
+                    st, wall, fwp, fwc = _send_and_parse_measurement(
+                        session=session,
+                        url=url,
+                        api_key=api_key,
+                        model=model,
+                        prompt_token_ids=prompt_token_ids,
+                        max_tokens=max_tokens,
+                        cached_tokens=cached_tokens,
                     )
 
                 logger.info(
@@ -658,8 +855,38 @@ def main() -> None:
         default=30.0,
         help="Seconds to sleep between retries (default: 30).",
     )
+    parser.add_argument(
+        "--num-servers",
+        type=int,
+        default=1,
+        help="Number of generator servers to fan requests out across via "
+        "x-fireworks-generator-worker-service-index. Inline (non-disagg) "
+        "deployments only - in tiered-disagg this only pins the generator side, "
+        "not the prefiller. Requires enableGeneratorWorkerTargeting=true on the "
+        "deployment; otherwise the header is ignored. Default: 1.",
+    )
+    parser.add_argument(
+        "--num-generators-per-server",
+        type=int,
+        default=1,
+        help="Number of data-parallel generators per server, used as the "
+        "round-robin range for x-fireworks-generator-worker-local-index. When "
+        "either this or --num-servers is greater than 1, each pair's batch_size "
+        "prompts are split round-robin across num_servers * num_local cells "
+        "(one multi-prompt request per cell, all firing concurrently); per-cell "
+        "load = batch_size / total_cells, total deployment load matches the "
+        "no-routing baseline. Default: 1.",
+    )
 
     args = parser.parse_args()
+    if args.num_servers < 1:
+        parser.error("--num-servers must be >= 1")
+    if args.num_generators_per_server < 1:
+        parser.error("--num-generators-per-server must be >= 1")
+    routing = RoutingConfig(
+        num_servers=args.num_servers,
+        num_local=args.num_generators_per_server,
+    )
 
     max_seq_len = args.max_seq_len
     try:
@@ -692,6 +919,7 @@ def main() -> None:
         rng_seed=args.seed,
         retries=args.retries,
         retry_delay=args.retry_delay,
+        routing=routing,
     )
     if args.format == "csv":
         print(format_csv(rows))

--- a/llm_bench/prefill_load_test.py
+++ b/llm_bench/prefill_load_test.py
@@ -53,11 +53,11 @@ _LOCAL_INDEX_HEADER = "x-fireworks-generator-worker-local-index"
 class RoutingConfig:
     """Generator-worker routing knobs for the benchmark client.
 
-    `num_servers` and `num_local` define the round-robin space across
-    (service-index, local-index) cells. When at least one dimension is greater
+    `num_servers` and `num_gens` define the round-robin space across
+    (service-index, local-index) workers. When at least one dimension is greater
     than 1, each pair's `batch_size` prompts are split round-robin across
-    `num_servers * num_local` cells (one multi-prompt HTTP request per cell,
-    all firing concurrently). Per-cell load is `batch_size / total_cells` prompts;
+    `num_servers * num_gens` workers (one multi-prompt HTTP request per worker,
+    all firing concurrently). Per-worker load is `batch_size / total_workers` prompts;
     total deployment-level load matches the no-routing baseline.
 
     Inline (non-disagg) deployments only: in tiered-disagg this only pins the
@@ -66,33 +66,33 @@ class RoutingConfig:
     """
 
     num_servers: int = 1
-    num_local: int = 1
+    num_gens: int = 1
 
     @property
     def enabled(self) -> bool:
-        return self.num_servers > 1 or self.num_local > 1
+        return self.num_servers > 1 or self.num_gens > 1
 
     @property
-    def total_cells(self) -> int:
-        return self.num_servers * self.num_local
+    def total_workers(self) -> int:
+        return self.num_servers * self.num_gens
 
     def describe(self) -> str:
         if not self.enabled:
             return "off"
-        return f"server-first {self.num_servers}x{self.num_local}"
+        return f"server-first {self.num_servers}x{self.num_gens}"
 
 
-def routing_headers_for_slot(cfg: Optional[RoutingConfig], slot_idx: int) -> dict[str, str]:
-    """Return the routing headers to attach to the request for the given slot.
+def routing_headers_for_worker(cfg: Optional[RoutingConfig], worker_idx: int) -> dict[str, str]:
+    """Return the routing headers to attach to the request for the given worker.
 
-    Server-first cycling: with 2 servers x 4 locals and slot=2,4,6 the cells
+    Server-first cycling: with 2 servers x 4 locals and worker=2,4,6 the workers
     visited are (s0,l1),(s0,l2),(s0,l3) so the per-server distribution stays
-    balanced even at small slot counts.
+    balanced even at small worker counts.
     """
     if cfg is None or not cfg.enabled:
         return {}
-    total = cfg.num_servers * cfg.num_local
-    flat = slot_idx % total
+    total = cfg.num_servers * cfg.num_gens
+    flat = worker_idx % total
     server = flat % cfg.num_servers
     local = flat // cfg.num_servers
     return {_SERVICE_INDEX_HEADER: str(server), _LOCAL_INDEX_HEADER: str(local)}
@@ -443,7 +443,7 @@ def _send_and_parse_measurement(
     return st, wall, fwp, fwc
 
 
-def _measure_pair_split_across_cells(
+def _measure_pair_split_across_workers(
     *,
     routing: RoutingConfig,
     url: str,
@@ -453,68 +453,68 @@ def _measure_pair_split_across_cells(
     max_tokens: int,
     cached_tokens: int,
 ) -> tuple[float, float, Optional[int], Optional[int]]:
-    """Split the multi-prompt batch across cells, fire one chunk per cell concurrently.
+    """Split the multi-prompt batch across workers, fire one chunk per worker concurrently.
 
-    Stride-slices `prompt_token_ids` into routing.total_cells chunks
-    (prompts[i::total_cells]) so each cell processes ~batch_size/total_cells prompts
+    Stride-slices `prompt_token_ids` into routing.total_workers chunks
+    (prompts[i::total_workers]) so each worker processes ~batch_size/total_workers prompts
     in its own multi-prompt request. Total deployment-level work matches the
-    no-routing baseline; per-cell pressure is divided across cells. When
-    batch_size < total_cells, some chunks are empty and those cells are skipped.
+    no-routing baseline; per-worker pressure is divided across workers. When
+    batch_size < total_workers, some chunks are empty and those workers are skipped.
 
-    Reports max(server_duration), max(client_duration) across cells (latency
-    bottlenecked by slowest cell). Token counts are summed across cells (each
-    cell processed a distinct slice).
+    Reports max(server_duration), max(client_duration) across workers (latency
+    bottlenecked by slowest worker). Token counts are summed across workers (each
+    worker processed a distinct slice).
     """
-    total_cells = routing.total_cells
+    total_workers = routing.total_workers
     # Stride-slice for even round-robin distribution. Uneven splits handled
     # naturally (e.g. 1985 / 4 -> [497, 496, 496, 496]).
     chunks: list[list[list[int]]] = [
-        prompt_token_ids[i::total_cells] for i in range(total_cells)
+        prompt_token_ids[i::total_workers] for i in range(total_workers)
     ]
-    active_slots = [i for i, c in enumerate(chunks) if c]
+    active_workers = [i for i, c in enumerate(chunks) if c]
 
-    def _run_slot(slot_idx: int) -> tuple[int, float, float, Optional[int], Optional[int]]:
-        # Distinct session per cell to avoid HTTP/2 multiplexing bias on a shared session.
+    def _run_worker(worker_idx: int) -> tuple[int, float, float, Optional[int], Optional[int]]:
+        # Distinct session per worker to avoid HTTP/2 multiplexing bias on a shared session.
         s = requests.Session()
         try:
-            headers = routing_headers_for_slot(routing, slot_idx)
+            headers = routing_headers_for_worker(routing, worker_idx)
             st, wall, fwp, fwc = _send_and_parse_measurement(
                 session=s,
                 url=url,
                 api_key=api_key,
                 model=model,
-                prompt_token_ids=chunks[slot_idx],
+                prompt_token_ids=chunks[worker_idx],
                 max_tokens=max_tokens,
                 cached_tokens=cached_tokens,
                 extra_headers=headers,
             )
-            return slot_idx, st, wall, fwp, fwc
+            return worker_idx, st, wall, fwp, fwc
         finally:
             s.close()
 
-    with ThreadPoolExecutor(max_workers=len(active_slots)) as pool:
-        futures = [pool.submit(_run_slot, i) for i in active_slots]
-        per_cell = [fut.result() for fut in as_completed(futures)]
+    with ThreadPoolExecutor(max_workers=len(active_workers)) as pool:
+        futures = [pool.submit(_run_worker, i) for i in active_workers]
+        per_worker = [fut.result() for fut in as_completed(futures)]
 
-    per_cell.sort(key=lambda r: r[0])
+    per_worker.sort(key=lambda r: r[0])
     if logger.isEnabledFor(logging.DEBUG):
-        for slot_idx, st, wall, fwp, fwc in per_cell:
+        for worker_idx, st, wall, fwp, fwc in per_worker:
             logger.debug(
-                "  cell=%d chunk=%d server-duration=%.6fs client=%.2fs fwp=%s fwc=%s",
-                slot_idx,
-                len(chunks[slot_idx]),
+                "  worker=%d chunk=%d server-duration=%.6fs client=%.2fs fwp=%s fwc=%s",
+                worker_idx,
+                len(chunks[worker_idx]),
                 st,
                 wall,
                 fwp,
                 fwc,
             )
 
-    server_durations = [row[1] for row in per_cell]
-    client_durations = [row[2] for row in per_cell]
-    fwps = [row[3] for row in per_cell if row[3] is not None]
-    fwcs = [row[4] for row in per_cell if row[4] is not None]
-    # max() for latency: server is bottlenecked by the slowest cell.
-    # sum() for token counts: each cell processed its own slice; sum reconstructs
+    server_durations = [row[1] for row in per_worker]
+    client_durations = [row[2] for row in per_worker]
+    fwps = [row[3] for row in per_worker if row[3] is not None]
+    fwcs = [row[4] for row in per_worker if row[4] is not None]
+    # max() for latency: server is bottlenecked by the slowest worker.
+    # sum() for token counts: each worker processed its own slice; sum reconstructs
     # the deployment-level total for cross-checking against expected
     # batch_size * prompt_tokens / batch_size * cached_tokens.
     fwp_agg = sum(fwps) if fwps else None
@@ -613,15 +613,15 @@ def run_benchmark(
 
         for attempt in range(1, retries + 1):
             try:
-                # Warmup: prime cache on every cell we're about to measure. In
-                # routing mode, each cell needs its own warmup or the
-                # measurement on that cell will see a cache miss.
+                # Warmup: prime cache on every worker we're about to measure. In
+                # routing mode, each worker needs its own warmup or the
+                # measurement on that worker will see a cache miss.
                 if cached_tokens > 0:
                     if routing.enabled:
-                        for slot_idx in range(routing.total_cells):
+                        for worker_idx in range(routing.total_workers):
                             do_warmup(
                                 cached_tokens,
-                                extra_headers=routing_headers_for_slot(routing, slot_idx),
+                                extra_headers=routing_headers_for_worker(routing, worker_idx),
                             )
                     else:
                         do_warmup(cached_tokens)
@@ -653,7 +653,7 @@ def run_benchmark(
                 )
 
                 if routing.enabled:
-                    st, wall, fwp, fwc = _measure_pair_split_across_cells(
+                    st, wall, fwp, fwc = _measure_pair_split_across_workers(
                         routing=routing,
                         url=url,
                         api_key=api_key,
@@ -867,15 +867,17 @@ def main() -> None:
     )
     parser.add_argument(
         "--num-generators-per-server",
+        "--num-gens",
+        dest="num_generators_per_server",
         type=int,
         default=1,
         help="Number of data-parallel generators per server, used as the "
         "round-robin range for x-fireworks-generator-worker-local-index. When "
         "either this or --num-servers is greater than 1, each pair's batch_size "
-        "prompts are split round-robin across num_servers * num_local cells "
-        "(one multi-prompt request per cell, all firing concurrently); per-cell "
-        "load = batch_size / total_cells, total deployment load matches the "
-        "no-routing baseline. Default: 1.",
+        "prompts are split round-robin across num_servers * num_gens workers "
+        "(one multi-prompt request per worker, all firing concurrently); per-worker "
+        "load = batch_size / total_workers, total deployment load matches the "
+        "no-routing baseline. Alias matches fw-infer's --num-gens. Default: 1.",
     )
 
     args = parser.parse_args()
@@ -885,7 +887,7 @@ def main() -> None:
         parser.error("--num-generators-per-server must be >= 1")
     routing = RoutingConfig(
         num_servers=args.num_servers,
-        num_local=args.num_generators_per_server,
+        num_gens=args.num_generators_per_server,
     )
 
     max_seq_len = args.max_seq_len


### PR DESCRIPTION
### gen_load_test.py

- Added _SERVICE_INDEX_HEADER / _LOCAL_INDEX_HEADER constants and RoutingConfig(num_servers, num_local) dataclass with enabled, total_cells, and describe() helpers.

- Added routing_headers_for_slot(routing, slot_idx) that maps a slot index to {x-fireworks-generator-worker-service-index, x-fireworks-generator-worker-local-index} headers in server-first round-robin order.

- Threaded an extra_headers parameter through post_completion so callers can attach per-request routing headers without touching session state.

- _run_pair_separate_mode: each of the batch_size concurrent requests now gets a slot-indexed routing header ((slot_offset + i) % total_cells), so deployment-level load is spread evenly across cells with deterministic assignment per request.

- _warmup_seq_len: warmup now dispatches once per cell with that cell's routing header, so every cell that will receive measurement traffic has its prompt cache primed.

- Added CLI flags --num-servers and --num-generators-per-server (both default to 1).

- Default mode (no routing flags) is untouched: same single n=batch_size request, same user="0", same shared session.

### prefill_load_test.py

- Same shared infrastructure: _SERVICE_INDEX_HEADER, _LOCAL_INDEX_HEADER, RoutingConfig, routing_headers_for_slot, and extra_headers plumbed through post_completion.

- Factored the single-request send-and-parse path into _send_and_parse_measurement so the default and routed modes share parsing logic.

- Added _measure_pair_split_across_cells: stride-slices prompt_token_ids into total_cells chunks (prompts[i::total_cells]) and fires one multi-prompt request per cell concurrently via ThreadPoolExecutor. Per-cell load is ~batch_size / total_cells; total deployment-level load matches the no-routing baseline. Each cell uses its own requests.Session to avoid HTTP/2 multiplexing bias.

- Aggregation: max() across cells for server_duration and client_duration (server bottlenecked by slowest cell); sum() across cells for server_prompt_tokens and server_cached_tokens (each cell processed its own slice; sum reconstructs batch_size × prompt_tokens for cross-checking).

- DEBUG log per cell now includes the chunk size so per-cell skew is visible.

- Per-cell warmup: when routing is enabled, the warmup loop runs once per cell with that cell's routing headers, so every active cell's prompt cache is primed with the matching cached_tokens prefix.

- run_benchmark branches on routing.enabled — routed path calls _measure_pair_split_across_cells, default path calls _send_and_parse_measurement directly.

- Added CLI flags --num-servers and --num-generators-per-server (both default to 1). Uses generators per server since we can just benchmark dp modes with inline + routing setup

- Edge cases handled: empty chunks when batch_size < total_cells are skipped via active_slots filter (pool shrinks to non-empty cells); uneven splits fall out naturally from stride slicing (e.g. 1985/4 → [497, 496, 496, 496]); cached_tokens == 0 skips warmup as before.

- Default mode (no routing flags) is byte-identical to today: same single multi-prompt request, same user="0", same warmup, same shared session.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new routing modes that change how benchmark traffic is distributed (splitting batches and pinning requests to specific workers), which can alter measured latencies and warmup/cache behavior when enabled; default behavior remains unchanged when routing is off.
> 
> **Overview**
> Adds optional generator-worker routing to `gen_load_test.py` and `prefill_load_test.py` via `x-fireworks-generator-worker-service-index`/`x-fireworks-generator-worker-local-index` headers.
> 
> When `--num-servers` or `--num-gens` is set (>1), generation benchmarks switch from `n=batch_size` to **separate concurrent requests** pinned round-robin to workers (including routed warmups/pre-warmup), and prefill benchmarks **split each multi-prompt batch across workers** (concurrent per-worker requests) with per-worker cache warmup and aggregated timing/token metrics.
> 
> Introduces `RoutingConfig`, per-request `extra_headers` plumbing in `post_completion`, and new CLI flags/validation for routing configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a67799ce0ce72a7d8da2468e1d081cb674f2753. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->