### PR TITLE
llm_bench: support local DeepSeek V4 tokenizer assets

### DIFF
--- a/llm_bench/gen_load_test.py
+++ b/llm_bench/gen_load_test.py
@@ -87,6 +87,28 @@ _FAST_BATCH_SIZES = [1, 2, 3, 4, 5, 6, 7, 8]
 # NB: don't use power of 2 as we will use multiples of this to generate seq pairs
 # and in some cases it will batch max seq len of a model, which is the edge case we don't want to benchmark.
 _DEFAULT_MIN_SEQ_LEN = 1000
+_MAX_SEQ_LEN_CONFIG_FIELDS = (
+    "max_position_embeddings",
+    "model_max_length",
+    "max_sequence_length",
+    "seq_length",
+    "n_positions",
+)
+
+
+def _tokenizer_asset_path(tokenizer_path: str, filename: str) -> str:
+    if os.path.isdir(tokenizer_path):
+        path = os.path.join(tokenizer_path, filename)
+        if not os.path.isfile(path):
+            raise FileNotFoundError(f"Missing {filename} in local tokenizer directory {tokenizer_path}")
+        return path
+    return hf_hub_download(repo_id=tokenizer_path, filename=filename)
+
+
+def _read_config_json(tokenizer_path: str) -> dict[str, Any]:
+    config_path = _tokenizer_asset_path(tokenizer_path, "config.json")
+    with open(config_path) as f:
+        return json.load(f)
 
 
 def get_profile_batch_sizes(max_batch_size: int) -> list[int]:
@@ -112,20 +134,20 @@ def get_profile_batch_sizes(max_batch_size: int) -> list[int]:
 
 
 def resolve_max_seq_len(tokenizer_path: str) -> int:
-    config = transformers.AutoConfig.from_pretrained(tokenizer_path, trust_remote_code=True)
-    # For VLMs (e.g. Kimi K2.5, LLaMA Vision), max_position_embeddings lives
-    # under text_config rather than at the top level.
-    config = config.get_text_config()
-    for name in (
-        "max_position_embeddings",
-        "model_max_length",
-        "max_sequence_length",
-        "seq_length",
-        "n_positions",
-    ):
-        v = getattr(config, name, None)
-        if isinstance(v, int) and v > 0:
-            return v
+    try:
+        config = transformers.AutoConfig.from_pretrained(tokenizer_path, trust_remote_code=True)
+        # For VLMs (e.g. Kimi K2.5, LLaMA Vision), max_position_embeddings lives
+        # under text_config rather than at the top level.
+        configs: tuple[Any, ...] = (config.get_text_config(),)
+    except ValueError:
+        config_json = _read_config_json(tokenizer_path)
+        configs = (config_json.get("text_config") or {}, config_json)
+
+    for config in configs:
+        for name in _MAX_SEQ_LEN_CONFIG_FIELDS:
+            v = config.get(name) if isinstance(config, Mapping) else getattr(config, name, None)
+            if isinstance(v, int) and v > 0:
+                return v
     raise ValueError("Could not infer max sequence length from config; pass --max-seq-len explicitly.")
 
 
@@ -135,16 +157,14 @@ def resolve_model_type(tokenizer_path: str) -> str:
         text_config = config.get_text_config()
         return getattr(text_config, "model_type", None) or getattr(config, "model_type", "")
     except ValueError:
-        config_path = hf_hub_download(repo_id=tokenizer_path, filename="config.json")
-        with open(config_path) as f:
-            config_json = json.load(f)
+        config_json = _read_config_json(tokenizer_path)
         text_config = config_json.get("text_config") or {}
         return text_config.get("model_type") or config_json.get("model_type", "")
 
 
 @lru_cache(maxsize=None)
 def load_dsv4_encode_messages(tokenizer_path: str) -> Any:
-    path = hf_hub_download(repo_id=tokenizer_path, filename="encoding/encoding_dsv4.py")
+    path = _tokenizer_asset_path(tokenizer_path, "encoding/encoding_dsv4.py")
     spec = importlib.util.spec_from_file_location("hf_dsv4_encoding", path)
     if spec is None or spec.loader is None:
         raise RuntimeError(f"Could not load DSV4 encoding module from {path}")

--- a/llm_bench/prefill_load_test.py
+++ b/llm_bench/prefill_load_test.py
@@ -100,6 +100,28 @@ def routing_headers_for_worker(cfg: Optional[RoutingConfig], worker_idx: int) ->
 # NB: don't use power of 2 as we will use multiples of this to generate seq pairs
 # and in some cases it will batch max seq len of a model, which is the edge case we don't want to benchmark.
 _DEFAULT_MIN_SEQ_LEN = 500
+_MAX_SEQ_LEN_CONFIG_FIELDS = (
+    "max_position_embeddings",
+    "model_max_length",
+    "max_sequence_length",
+    "seq_length",
+    "n_positions",
+)
+
+
+def _tokenizer_asset_path(tokenizer_path: str, filename: str) -> str:
+    if os.path.isdir(tokenizer_path):
+        path = os.path.join(tokenizer_path, filename)
+        if not os.path.isfile(path):
+            raise FileNotFoundError(f"Missing {filename} in local tokenizer directory {tokenizer_path}")
+        return path
+    return hf_hub_download(repo_id=tokenizer_path, filename=filename)
+
+
+def _read_config_json(tokenizer_path: str) -> dict[str, Any]:
+    config_path = _tokenizer_asset_path(tokenizer_path, "config.json")
+    with open(config_path) as f:
+        return json.load(f)
 
 
 def _load_auto_tokenizer(tokenizer_path: str) -> transformers.PreTrainedTokenizer:
@@ -107,20 +129,20 @@ def _load_auto_tokenizer(tokenizer_path: str) -> transformers.PreTrainedTokenize
 
 
 def resolve_max_seq_len(tokenizer_path: str) -> int:
-    config = transformers.AutoConfig.from_pretrained(tokenizer_path, trust_remote_code=True)
-    # For VLMs (e.g. Kimi K2.5, LLaMA Vision), max_position_embeddings lives
-    # under text_config rather than at the top level.
-    config = config.get_text_config()
-    for name in (
-        "max_position_embeddings",
-        "model_max_length",
-        "max_sequence_length",
-        "seq_length",
-        "n_positions",
-    ):
-        v = getattr(config, name, None)
-        if isinstance(v, int) and v > 0:
-            return v
+    try:
+        config = transformers.AutoConfig.from_pretrained(tokenizer_path, trust_remote_code=True)
+        # For VLMs (e.g. Kimi K2.5, LLaMA Vision), max_position_embeddings lives
+        # under text_config rather than at the top level.
+        configs: tuple[Any, ...] = (config.get_text_config(),)
+    except ValueError:
+        config_json = _read_config_json(tokenizer_path)
+        configs = (config_json.get("text_config") or {}, config_json)
+
+    for config in configs:
+        for name in _MAX_SEQ_LEN_CONFIG_FIELDS:
+            v = config.get(name) if isinstance(config, Mapping) else getattr(config, name, None)
+            if isinstance(v, int) and v > 0:
+                return v
     raise ValueError("Could not infer max sequence length from config; pass --max-seq-len explicitly.")
 
 
@@ -130,16 +152,14 @@ def resolve_model_type(tokenizer_path: str) -> str:
         text_config = config.get_text_config()
         return getattr(text_config, "model_type", None) or getattr(config, "model_type", "")
     except ValueError:
-        config_path = hf_hub_download(repo_id=tokenizer_path, filename="config.json")
-        with open(config_path) as f:
-            config_json = json.load(f)
+        config_json = _read_config_json(tokenizer_path)
         text_config = config_json.get("text_config") or {}
         return text_config.get("model_type") or config_json.get("model_type", "")
 
 
 @lru_cache(maxsize=None)
 def load_dsv4_encode_messages(tokenizer_path: str) -> Any:
-    path = hf_hub_download(repo_id=tokenizer_path, filename="encoding/encoding_dsv4.py")
+    path = _tokenizer_asset_path(tokenizer_path, "encoding/encoding_dsv4.py")
     spec = importlib.util.spec_from_file_location("hf_dsv4_encoding", path)
     if spec is None or spec.loader is None:
         raise RuntimeError(f"Could not load DSV4 encoding module from {path}")


### PR DESCRIPTION
## Summary
- Prefer local tokenizer asset paths before falling back to Hugging Face Hub downloads.
- Apply the local asset lookup to DeepSeek V4 `config.json` and `encoding/encoding_dsv4.py` in generation and prefill load tests.

## Test plan
- `python3 -m py_compile benchmark/llm_bench/gen_load_test.py benchmark/llm_bench/prefill_load_test.py`
- `conda run -n perfagent python gen_load_test.py --tokenizer /Users/sandeepsingh/src/fireworks/.tmp/dsv4-tokenizer --model accounts/pyroworks/deployments/iwyz07qb --base-url https://api.fireworks.ai/inference --seq-batch-pairs 1000:1 --max-tokens 1 --retries 1 --retry-delay 1 -f csv`
- `conda run -n perfagent python prefill_load_test.py --tokenizer /Users/sandeepsingh/src/fireworks/.tmp/dsv4-tokenizer --model accounts/pyroworks/deployments/iwyz07qb --base-url https://api.fireworks.ai/inference --seq-pairs 500:0 --min-tokens-to-batch 500 --max-tokens 0 --retries 1 --retry-delay 1 -f csv`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to benchmark scripts and primarily adjust tokenizer asset lookup and config parsing fallbacks; main failure mode is a clearer error if expected local files are missing.
> 
> **Overview**
> **Load tests now support local tokenizer directories.** `gen_load_test.py` and `prefill_load_test.py` add `_tokenizer_asset_path()` and `_read_config_json()` to load `config.json` and `encoding/encoding_dsv4.py` from a local `--tokenizer` directory when present, otherwise downloading via `hf_hub_download`.
> 
> **More robust max-seq-len inference.** `resolve_max_seq_len()` now falls back to parsing `config.json` (including `text_config`) when `AutoConfig.from_pretrained()` fails, and centralizes the list of config fields checked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d4c25e532816e405dcb744d0152016300c5e745. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->