### PR TITLE
Add --min-batch-size to gen_load_test

### DIFF
--- a/llm_bench/gen_load_test.py
+++ b/llm_bench/gen_load_test.py
@@ -89,15 +89,18 @@ _FAST_BATCH_SIZES = [1, 2, 3, 4, 5, 6, 7, 8]
 _DEFAULT_MIN_SEQ_LEN = 1000
 
 
-def get_profile_batch_sizes(max_batch_size: int) -> list[int]:
-    r = [b for b in _FAST_BATCH_SIZES if b <= max_batch_size]
+def get_profile_batch_sizes(max_batch_size: int, min_batch_size: int = 1) -> list[int]:
+    r = [b for b in _FAST_BATCH_SIZES if min_batch_size <= b <= max_batch_size]
     if not r:
-        return [max_batch_size]
+        if min_batch_size <= max_batch_size:
+            return [max_batch_size]
+        return []
 
     step = 4
     b = r[-1] + step
     while b <= max_batch_size:
-        r.append(b)
+        if b >= min_batch_size:
+            r.append(b)
         if (b & (b - 1)) == 0:
             if 32 <= b < 128:
                 step = 16
@@ -105,7 +108,7 @@ def get_profile_batch_sizes(max_batch_size: int) -> list[int]:
                 step = b // 2
         b += step
 
-    if r[-1] != max_batch_size:
+    if r[-1] != max_batch_size and max_batch_size >= min_batch_size:
         r.append(max_batch_size)
 
     return r
@@ -869,6 +872,12 @@ def main() -> None:
         help="Max batch size for auto-generated pairs (default: 128). " "Ignored when --seq-batch-pairs is given.",
     )
     parser.add_argument(
+        "--min-batch-size",
+        type=int,
+        default=1,
+        help="Min batch size for auto-generated pairs (default: 1). " "Ignored when --seq-batch-pairs is given.",
+    )
+    parser.add_argument(
         "--max-kv-cache-entries",
         type=int,
         default=None,
@@ -932,13 +941,16 @@ def main() -> None:
         "round-robin range for x-fireworks-generator-worker-local-index. "
         "Alias matches fw-infer's --num-gens. Default: 1.",
     )
-
     args = parser.parse_args()
 
     if args.num_servers < 1:
         parser.error("--num-servers must be >= 1")
     if args.num_generators_per_server < 1:
         parser.error("--num-generators-per-server must be >= 1")
+    if args.min_batch_size < 1:
+        parser.error("--min-batch-size must be >= 1")
+    if args.min_batch_size > args.max_batch_size:
+        parser.error("--min-batch-size must be <= --max-batch-size")
     routing = RoutingConfig(
         num_servers=args.num_servers,
         num_gens=args.num_generators_per_server,
@@ -963,7 +975,7 @@ def main() -> None:
             elif hf_max_seq_len is not None:
                 max_seq_len = min(max_seq_len, hf_max_seq_len)
             seq_lens = generate_seq_lens(args.min_seq_len, max_seq_len)
-        batch_sizes = get_profile_batch_sizes(args.max_batch_size)
+        batch_sizes = get_profile_batch_sizes(args.max_batch_size, args.min_batch_size)
         pairs = [(s, b) for s in seq_lens for b in batch_sizes]
 
     if args.max_kv_cache_entries is not None:

--- a/llm_bench/gen_load_test.py
+++ b/llm_bench/gen_load_test.py
@@ -90,17 +90,17 @@ _DEFAULT_MIN_SEQ_LEN = 1000
 
 
 def get_profile_batch_sizes(max_batch_size: int, min_batch_size: int = 1) -> list[int]:
+    if min_batch_size > max_batch_size:
+        return []
+
     r = [b for b in _FAST_BATCH_SIZES if min_batch_size <= b <= max_batch_size]
     if not r:
-        if min_batch_size <= max_batch_size:
-            return [max_batch_size]
-        return []
+        r = [min_batch_size]
 
     step = 4
     b = r[-1] + step
     while b <= max_batch_size:
-        if b >= min_batch_size:
-            r.append(b)
+        r.append(b)
         if (b & (b - 1)) == 0:
             if 32 <= b < 128:
                 step = 16
@@ -108,7 +108,7 @@ def get_profile_batch_sizes(max_batch_size: int, min_batch_size: int = 1) -> lis
                 step = b // 2
         b += step
 
-    if r[-1] != max_batch_size and max_batch_size >= min_batch_size:
+    if r[-1] != max_batch_size:
         r.append(max_batch_size)
 
     return r


### PR DESCRIPTION
## Summary
- Add `--min-batch-size` to `gen_load_test.py` for auto-generated batch size grids (default 1).
- Filter the dense 1–8 block and coarser stepping grid to skip batch sizes below the minimum.

## Test plan
- [ ] `python gen_load_test.py ... --min-batch-size 8 --max-batch-size 512` starts grid at bs=8
- [ ] Default behavior unchanged (`--min-batch-size 1`)

## Dependencies
- Paired with fw-ai/fireworks perfagent CI wiring and fw-ai/configs GLM sweep YAML.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is confined to benchmark CLI argument parsing and batch-size grid generation with added validation; default behavior remains the same when unset.
> 
> **Overview**
> Adds `--min-batch-size` to `gen_load_test.py` and validates it (>=1 and <= `--max-batch-size`).
> 
> Updates `get_profile_batch_sizes` and the auto-generated seq/batch pair generation to **filter out batch sizes below the minimum**, falling back to `min_batch_size` when the dense 1–8 block is entirely skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4893e6aac1ac24153d851c792e3ffaeadd3060d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->