### PR TITLE
llm_bench: add --targets for multi-deployment load testing

### DIFF
--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -627,6 +627,30 @@ def _defer_run_time_to_after_spawn(environment, **_kwargs):
         logger.info(f"Will stop after {max_requests} requests complete")
 
 
+@events.init.add_listener
+def _scale_users_by_targets(environment, **_kwargs):
+    """Multiply -u/--users and --spawn-rate by the number of --targets entries.
+
+    With this, -u 100 means "100 users per target": the user specifies per-target
+    load and the script scales the total locust user count up to match. spawn-rate
+    is multiplied proportionally so the ramp-up rate per target stays the same.
+    """
+    targets = getattr(environment.parsed_options, "targets", None) or []
+    n = len(targets)
+    if n <= 1:
+        return
+    num_users = getattr(environment.parsed_options, "num_users", None)
+    if num_users:
+        environment.parsed_options.num_users = num_users * n
+        logger.info(
+            f"Scaling --users by {n} targets: {num_users} -> {num_users * n} "
+            f"(stays {num_users} per target)"
+        )
+    spawn_rate = getattr(environment.parsed_options, "spawn_rate", None)
+    if spawn_rate:
+        environment.parsed_options.spawn_rate = spawn_rate * n
+
+
 @dataclass
 class ChunkMetadata:
     text: str
@@ -1727,7 +1751,8 @@ def init_parser(parser):
             "(pipe-separated, all but url optional). Repeat the flag for multiple targets. "
             "When set, users are assigned round-robin across targets; --host/--model/--api-key "
             "act as fallbacks for fields the per-target spec leaves blank. "
-            "To match load per target, pass --users N*<num_targets>. "
+            "-u/--users is interpreted per-target: -u 100 with two targets spawns 200 total "
+            "users (100 hitting each target). --spawn-rate is scaled the same way. "
             "Request stats are grouped per target via the request name prefix."
         ),
     )

--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -1747,13 +1747,9 @@ def init_parser(parser):
         action="append",
         default=[],
         help=(
-            "Target deployment to forward traffic to. Format: 'url[|model][|api_key]' "
-            "(pipe-separated, all but url optional). Repeat the flag for multiple targets. "
-            "When set, users are assigned round-robin across targets; --host/--model/--api-key "
-            "act as fallbacks for fields the per-target spec leaves blank. "
-            "-u/--users is interpreted per-target: -u 100 with two targets spawns 200 total "
-            "users (100 hitting each target). --spawn-rate is scaled the same way. "
-            "Request stats are grouped per target via the request name prefix."
+            "Target URL. Repeat for multiple targets. Format: 'url[|model][|api_key]' "
+            "(model and api_key optional, fall back to --model/--api-key). "
+            "With multiple targets, -u/--users is per-target (total = users * num_targets)."
         ),
     )
     parser.add_argument(

--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -473,9 +473,17 @@ class InitTracker:
         if cls.logging_params is None:
             cls.logging_params = logging_params
         else:
+            # Multi-target runs intentionally use a different model per user;
+            # drop fields that are expected to differ across targets before comparing.
+            multi_target = bool(getattr(environment.parsed_options, "targets", None))
+            if multi_target:
+                existing = {k: v for k, v in cls.logging_params.items() if k != "model"}
+                incoming = {k: v for k, v in logging_params.items() if k != "model"}
+            else:
+                existing, incoming = cls.logging_params, logging_params
             assert (
-                cls.logging_params == logging_params
-            ), f"Inconsistent settings between workers: {cls.logging_params} != {logging_params}"
+                existing == incoming
+            ), f"Inconsistent settings between workers: {existing} != {incoming}"
 
     @classmethod
     def notify_first_request(cls):

--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -1205,12 +1205,23 @@ class LLMUser(HttpUser):
         default_host = environment.host
         default_model = environment.parsed_options.model
         default_api_key = environment.parsed_options.api_key
+        def _label(url, model):
+            # Make the label distinguish targets even when they share a URL but
+            # differ by model (common with Fireworks deployment-pinned model
+            # strings of the form 'accounts/x/models/y#accounts/x/deployments/z').
+            if model and "#" in model:
+                # Use the deployment id (right of '#') — short and human-recognizable.
+                return model.rsplit("/", 1)[-1]
+            if model:
+                return f"{url} {model}"
+            return url or "default"
+
         if not raw:
             return [{
                 "url": default_host,
                 "model": default_model,
                 "api_key": default_api_key,
-                "label": default_host or "default",
+                "label": _label(default_host, default_model),
             }]
         parsed = []
         for spec in raw:
@@ -1222,7 +1233,7 @@ class LLMUser(HttpUser):
                 "url": url,
                 "model": model,
                 "api_key": api_key,
-                "label": url,
+                "label": _label(url, model),
             })
         return parsed
 

--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -1164,6 +1164,47 @@ def _load_curl_like_data(text):
 class LLMUser(HttpUser):
     # no wait time, so every user creates a continuous load, sending requests as quickly as possible
 
+    _target_counter = 0
+    _target_counter_lock = threading.Lock()
+
+    @staticmethod
+    def _parse_targets(environment):
+        raw = environment.parsed_options.targets or []
+        default_host = environment.host
+        default_model = environment.parsed_options.model
+        default_api_key = environment.parsed_options.api_key
+        if not raw:
+            return [{
+                "url": default_host,
+                "model": default_model,
+                "api_key": default_api_key,
+                "label": default_host or "default",
+            }]
+        parsed = []
+        for spec in raw:
+            parts = spec.split("|")
+            url = parts[0] or default_host
+            model = (parts[1] if len(parts) > 1 and parts[1] else default_model)
+            api_key = (parts[2] if len(parts) > 2 and parts[2] else default_api_key)
+            parsed.append({
+                "url": url,
+                "model": model,
+                "api_key": api_key,
+                "label": url,
+            })
+        return parsed
+
+    def __init__(self, environment):
+        targets = self._parse_targets(environment)
+        with LLMUser._target_counter_lock:
+            idx = LLMUser._target_counter % len(targets)
+            LLMUser._target_counter += 1
+        self._target = targets[idx]
+        # Override self.host before HttpUser.__init__ creates the HttpSession
+        if self._target["url"]:
+            self.host = self._target["url"]
+        super().__init__(environment)
+
     def on_start(self):
         try:
             self._on_start()
@@ -1173,7 +1214,7 @@ class LLMUser(HttpUser):
             sys.exit(1)
 
     def _guess_provider(self):
-        self.model = self.environment.parsed_options.model
+        self.model = self._target.get("model") or self.environment.parsed_options.model
         self.provider = self.environment.parsed_options.provider
         # guess based on URL
         if self.provider is None:
@@ -1223,8 +1264,9 @@ class LLMUser(HttpUser):
 
     def _on_start(self):
         self.client.headers["Content-Type"] = "application/json"
-        if self.environment.parsed_options.api_key:
-            self.client.headers["Authorization"] = "Bearer " + self.environment.parsed_options.api_key
+        api_key = self._target.get("api_key") or self.environment.parsed_options.api_key
+        if api_key:
+            self.client.headers["Authorization"] = "Bearer " + api_key
         if self.environment.parsed_options.header:
             for header in self.environment.parsed_options.header:
                 key, val = header.split(":", 1)
@@ -1444,6 +1486,7 @@ class LLMUser(HttpUser):
             stream=True,
             catch_response=True,
             timeout=60,
+            name=f"[{self._target['label']}] {self.provider_formatter.get_url()}",
         ) as response:
             combined_text = ""
             done = False
@@ -1674,6 +1717,19 @@ def init_parser(parser):
         env_var="MODEL",
         type=str,
         help="The model to use for generating text. If not specified we will pick the first model from the service as returned by /v1/models",
+    )
+    parser.add_argument(
+        "--targets",
+        action="append",
+        default=[],
+        help=(
+            "Target deployment to forward traffic to. Format: 'url[|model][|api_key]' "
+            "(pipe-separated, all but url optional). Repeat the flag for multiple targets. "
+            "When set, users are assigned round-robin across targets; --host/--model/--api-key "
+            "act as fallbacks for fields the per-target spec leaves blank. "
+            "To match load per target, pass --users N*<num_targets>. "
+            "Request stats are grouped per target via the request name prefix."
+        ),
     )
     parser.add_argument(
         "--tokenizer",


### PR DESCRIPTION
## Summary
- Adds repeatable `--targets` flag (format `url[|model][|api_key]`) so one locust run can drive multiple deployments.
- Users are assigned round-robin across targets; `--host` / `--model` / `--api-key` act as fallbacks for fields left blank in a per-target spec.
- `-u/--users` is interpreted **per-target**: with N targets, total locust users = `users × N` (so the value passed is "load per deployment"). `--spawn-rate` is scaled the same way.
- Each request is tagged `[<target_url>] /<path>` in the locust stats name, so per-target latency / throughput / failure rate show up as separate rows in the summary.
- Backward-compatible: when `--targets` is unset, behavior is unchanged.

## Motivation
Use case: comparing two pyroworks GB200 deployments (different prefill counts) under matched synthetic load without spinning up two locust processes. The native traffic-forker was blocked by an arch mismatch (forker image is amd64-only, deployments run on arm64 GB200 nodes), so doing it from locust is the next-best option for now.

## Usage
```bash
# Single target — unchanged behavior
locust -f load_test.py --host=https://api.fireworks.ai/inference --model=accounts/foo/models/bar

# Two targets, 100 users PER TARGET (script spawns 200 total)
locust -f load_test.py --headless -u 100 -r 10 \
  --host=https://api.fireworks.ai/inference \
  --api-key=$FIREWORKS_API_KEY \
  --targets="https://api.fireworks.ai/inference|accounts/pyroworks/deployedModels/cursor-clone-1-prefill-2" \
  --targets="https://api.fireworks.ai/inference|accounts/pyroworks/deployedModels/cursor-clone-2-prefill"
```

## Test plan
- [ ] `python -c "import ast; ast.parse(open('llm_bench/load_test.py').read())"` passes (verified locally)
- [ ] Single-target run (no `--targets`) — confirm old behavior unchanged
- [ ] Two-target run with `-u 100` — confirm total spawned users = 200, stats table shows one row per target, request counts split roughly evenly
- [ ] Per-target `--api-key` honored when provided in the target spec

## Caveats
- `_target_counter` is a class attr — in distributed locust each worker has its own counter (round-robin within worker, not globally). Fine for matched-load comparisons; not a perfectly even split across workers.
- Target label uses the URL. If two targets share the same URL but differ by model, labels collide; happy to switch the label to include model if that's a real case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the llm_bench Locust script and remain backward-compatible when `--targets` is omitted; no production auth or data paths are touched.
> 
> **Overview**
> Adds repeatable **`--targets`** (`url[|model][|api_key]`) so one Locust run can load several deployments. On init, **`-u` and `--spawn-rate` are multiplied by the number of targets** so the CLI value means load per target; users are assigned **round-robin** to a target with that target’s host, model, and optional API key (global `--host` / `--model` / `--api-key` fill blanks).
> 
> **`InitTracker.notify_init`** no longer treats differing **`model`** across workers as inconsistent when `--targets` is set. HTTP stats use **`[<label>] <path>`** so latency and failures split by target; labels prefer deployment id when the model string contains **`#`**.
> 
> Without **`--targets`**, behavior stays the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ff4c812ad8795da539c8b59463dd42749be4640. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->