### PR TITLE
[dsv4] Tokenizer support

### DIFF
--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -2,14 +2,16 @@ import abc
 import argparse
 import csv
 from dataclasses import dataclass
-from functools import partial
+from functools import lru_cache, partial
+import importlib.util
+import json
 import logging
 import os
 import random
 import sys
 import threading
 import traceback
-from typing import Optional
+from typing import Any, Optional
 from locust import HttpUser, task, events, constant_pacing
 import copy
 import json
@@ -54,6 +56,81 @@ DEFAULT_TOKENIZER = "NousResearch/Meta-Llama-3.1-8B-Instruct"
 def _load_auto_tokenizer(tokenizer_path: str):
     _install_transformers_tokenizer_compat_shim()
     return transformers.AutoTokenizer.from_pretrained(tokenizer_path, trust_remote_code=True)
+
+
+def _tokenizer_asset_path(tokenizer_path: str, filename: str) -> str:
+    if os.path.isdir(tokenizer_path):
+        path = os.path.join(tokenizer_path, filename)
+        if not os.path.isfile(path):
+            raise FileNotFoundError(f"Missing {filename} in local tokenizer directory {tokenizer_path}")
+        return path
+    from huggingface_hub import hf_hub_download
+
+    return hf_hub_download(repo_id=tokenizer_path, filename=filename)
+
+
+def _read_config_json(tokenizer_path: str) -> dict[str, Any]:
+    config_path = _tokenizer_asset_path(tokenizer_path, "config.json")
+    with open(config_path) as f:
+        return json.load(f)
+
+
+def resolve_model_type(tokenizer_path: str) -> str:
+    try:
+        config = transformers.AutoConfig.from_pretrained(tokenizer_path, trust_remote_code=True)
+        text_config = config.get_text_config()
+        return getattr(text_config, "model_type", None) or getattr(config, "model_type", "")
+    except ValueError:
+        config_json = _read_config_json(tokenizer_path)
+        text_config = config_json.get("text_config") or {}
+        return text_config.get("model_type") or config_json.get("model_type", "")
+
+
+@lru_cache(maxsize=None)
+def load_dsv4_encode_messages(tokenizer_path: str) -> Any:
+    path = _tokenizer_asset_path(tokenizer_path, "encoding/encoding_dsv4.py")
+    spec = importlib.util.spec_from_file_location("hf_dsv4_encoding", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load DSV4 encoding module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.encode_messages
+
+
+def _normalize_token_ids(obj: Any) -> list[int]:
+    ids = getattr(obj, "ids", None)
+    if ids is not None:
+        return [int(t) for t in ids]
+    input_ids = getattr(obj, "input_ids", None)
+    if input_ids is not None:
+        flat = input_ids[0] if input_ids and isinstance(input_ids[0], list) else input_ids
+        return [int(t) for t in flat]
+    tolist = getattr(obj, "tolist", None)
+    if callable(tolist):
+        flat = tolist()
+        if flat and isinstance(flat[0], list):
+            flat = flat[0]
+        return [int(t) for t in flat]
+    return [int(t) for t in obj]
+
+
+def empty_chat_template_token_ids(
+    tokenizer: transformers.PreTrainedTokenizer,
+    tokenizer_path: str,
+) -> list[int]:
+    """Token ids for chat template overhead (empty user message + generation prompt)."""
+    model_type = resolve_model_type(tokenizer_path)
+    if model_type == "deepseek_v4":
+        encode_messages = load_dsv4_encode_messages(tokenizer_path)
+        prompt = encode_messages([{"role": "user", "content": ""}], thinking_mode="chat")
+        return _normalize_token_ids(tokenizer.encode(prompt, add_special_tokens=False))
+    return _normalize_token_ids(
+        tokenizer.apply_chat_template(
+            [{"role": "user", "content": ""}],
+            tokenize=True,
+            add_generation_prompt=True,
+        )
+    )
 
 
 def add_custom_metric(name, value, length_value=0):
@@ -104,11 +181,13 @@ class TranslationDataset:
         path: str,
         prompt: str,
         tokenizer,
+        tokenizer_path: str,
         chat: bool,
         num_tokens: int,
         common_tokens: int,
     ):
         self._tokenizer = tokenizer
+        self._tokenizer_path = tokenizer_path
         self._num_tokens = num_tokens
 
         self._all_limericks = []
@@ -132,12 +211,8 @@ class TranslationDataset:
             idx += 1
 
         if chat:
-            empty_tempalate_tokens = self._tokenizer.apply_chat_template(
-                [{"role": "user", "content": ""}],
-                tokenize=True,
-                add_generation_prompt=True,
-            )
-            self._prefix_suffix_tokens += len(empty_tempalate_tokens)
+            empty_template_tokens = empty_chat_template_token_ids(self._tokenizer, self._tokenizer_path)
+            self._prefix_suffix_tokens += len(empty_template_tokens)
 
     def __next__(self):
         prompt_tokens = self._prefix_suffix_tokens
@@ -221,10 +296,12 @@ class DatasetHolder:
             common_tokens = options.prompt_cache_max_len
             if common_tokens > options.prompt_tokens:
                 common_tokens = options.prompt_tokens
+            tokenizer_path = options.tokenizer or DEFAULT_TOKENIZER
             return TranslationDataset(
                 path=os.path.join(os.path.dirname(os.path.abspath(__file__)), dataset_file),
                 prompt="\n\n" + prompt,
                 tokenizer=InitTracker.load_tokenizer(options.tokenizer),
+                tokenizer_path=tokenizer_path,
                 chat=options.chat and not getattr(options, "rerank", False),
                 num_tokens=options.prompt_tokens,
                 common_tokens=common_tokens,
@@ -257,6 +334,7 @@ class DatasetHolder:
                 path=path,
                 prompt="",
                 tokenizer=InitTracker.load_tokenizer(tokenizer),
+                tokenizer_path=tokenizer or DEFAULT_TOKENIZER,
                 chat=False,
                 num_tokens=max_tokens,
                 common_tokens=0,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are confined to LLM benchmark prompt token accounting; non-DSV4 behavior is unchanged and failures would mainly skew load-test metrics, not production serving.
> 
> **Overview**
> Adds **DeepSeek V4 (DSV4)** support to the Locust `load_test` harness so chat-mode prompt sizing matches models that ship a custom encoder instead of a standard Hugging Face chat template.
> 
> When building synthetic prompts, chat template overhead is now computed via `empty_chat_template_token_ids`, which resolves `model_type` from the tokenizer repo (local dir or HF) and, for `deepseek_v4`, dynamically loads `encoding/encoding_dsv4.py` and uses `encode_messages` before tokenizing. Other models still use `apply_chat_template` as before.
> 
> `TranslationDataset` and `DatasetHolder` now pass through `tokenizer_path` so this logic can fetch config and encoding assets from the same source as `--tokenizer`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 415a5e732c7dbd0242336ec6442c03579a510711. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->