### PR TITLE
fix: add units to result summary output

### DIFF
--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -2173,7 +2173,7 @@ def _(environment, **kw):
     def pretty_name(s):
         base = s
         # Strip percentile prefix (e.g. "P50_total_latency" -> "total_latency")
-        for prefix in ("P50_", "P90_", "P95_", "P99_", "P99.9_"):
+        for prefix in ("P50_", "P90_", "P95_", "P99.9_", "P99_"):
             if s.startswith(prefix):
                 base = s[len(prefix):]
                 break

--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -2162,7 +2162,25 @@ def _(environment, **kw):
             name = f"P{percentile}_{percentile_metric}"
             entries[name] = metric_entry.get_response_time_percentile(percentile / 100)
 
-    pretty_name = lambda s: " ".join([w.capitalize() for w in s.split("_")])
+    ms_metrics = {
+        "time_to_first_token",
+        "latency_per_token",
+        "overall_latency_per_token",
+        "total_latency",
+        "latency_per_embedding",
+        "latency_per_char",
+    }
+    def pretty_name(s):
+        base = s
+        # Strip percentile prefix (e.g. "P50_total_latency" -> "total_latency")
+        for prefix in ("P50_", "P90_", "P95_", "P99_", "P99.9_"):
+            if s.startswith(prefix):
+                base = s[len(prefix):]
+                break
+        label = " ".join([w.capitalize() for w in s.split("_")])
+        if base in ms_metrics:
+            label += " (ms)"
+        return label
     entries = {pretty_name(k): v for k, v in entries.items()}
 
     # print in the final event handler to make sure our output is the last one


### PR DESCRIPTION
## Summary

- Appends `(ms)` to all time-based metric labels in the summary output, so users can immediately tell what unit each value uses
- Covers base metrics (`Time To First Token`, `Latency Per Token`, `Overall Latency Per Token`, `Total Latency`, `Latency Per Embedding`, `Latency Per Char`) and their percentile variants (`P50`, `P90`, `P95`, `P99`, `P99.9`)

Closes #5

### Before

```
Time To First Token: 5.705300167132269
Latency Per Token  : 135.50119360148753
Total Latency      : 28838.560053018486
```

### After

```
Time To First Token (ms): 5.705300167132269
Latency Per Token (ms)  : 135.50119360148753
Total Latency (ms)      : 28838.560053018486
```

## Test plan

- [ ] Run a load test with `--stream` and verify summary labels show `(ms)` for time-based metrics
- [ ] Run with `--embeddings` and verify `Latency Per Embedding (ms)` appears
- [ ] Confirm non-time metrics (e.g. `Num Tokens`, `Qps`, `Prompt Tokens`) do **not** get a unit suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only label formatting in the quit summary and optional CSV export; no change to measured values or request behavior.
> 
> **Overview**
> Load test **summary output** (console and `--summary-file` CSV column headers) now appends **` (ms)`** to labels for time-based metrics.
> 
> The one-line `pretty_name` lambda is replaced with logic that maps known latency metrics (`time_to_first_token`, `latency_per_token`, `overall_latency_per_token`, `total_latency`, `latency_per_embedding`, `latency_per_char`) and their **percentile variants** (e.g. `P50_total_latency`) by stripping the `P50_` / `P90_` / etc. prefix before deciding whether to add the unit suffix. Count/rate fields like QPS and token counts are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aee97902d8a4cf9548c3967f553830cadbf6be61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->