### PR TITLE
Make load_test.py use strict token-id prompts (PER-75)

### DIFF
--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -175,7 +175,101 @@ PROMPT_PREFIX_TOKEN = "Pad "  # exactly one token
 PROMPT_CHAT_IMAGE_PLACEHOLDER = "<image>"
 
 
+def _load_chunks(path: str) -> list[str]:
+    with open(path, "r") as f:
+        text = f.read()
+    chunks = [p for p in text.split("\n\n") if p.strip()]
+    if not chunks:
+        raise ValueError(f"No chunks in {path}")
+    return chunks
+
+
+def _build_ids_to_length(tokenizer, chunks: list[str], target_len: int) -> list[int]:
+    ids: list[int] = []
+    i = 0
+    while len(ids) < target_len and i < 1_000_000:
+        lim = chunks[i % len(chunks)]
+        ids.extend(tokenizer.encode(lim + "\n\n", add_special_tokens=False))
+        i += 1
+    return ids[:target_len]
+
+
+def _build_random_suffix_ids(
+    tokenizer, chunks: list[str], need_len: int, rng: random.Random
+) -> list[int]:
+    if need_len <= 0:
+        return []
+    ids: list[int] = []
+    i = 0
+    while len(ids) < need_len and i < 1_000_000:
+        lim = rng.choice(chunks)
+        ids.extend(tokenizer.encode(lim + "\n\n", add_special_tokens=False))
+        i += 1
+    return ids[:need_len]
+
+
+def _split_chat_template(
+    tokenizer, tokenizer_path: str, model_type: str
+) -> tuple[list[int], list[int]]:
+    sentinel = "abcdefghij"
+    sentinel_ids = _normalize_token_ids(tokenizer.encode(sentinel, add_special_tokens=False))
+    if not sentinel_ids:
+        raise RuntimeError("Sentinel tokenized to empty id list; cannot split chat template.")
+    if model_type == "deepseek_v4":
+        encode_messages = load_dsv4_encode_messages(tokenizer_path)
+        prompt = encode_messages([{"role": "user", "content": sentinel}], thinking_mode="chat")
+        templated = _normalize_token_ids(tokenizer.encode(prompt, add_special_tokens=False))
+    else:
+        templated = _normalize_token_ids(
+            tokenizer.apply_chat_template(
+                [{"role": "user", "content": sentinel}],
+                tokenize=True,
+                add_generation_prompt=True,
+            )
+        )
+    n = len(sentinel_ids)
+    for i in range(len(templated) - n + 1):
+        if templated[i : i + n] == sentinel_ids:
+            return templated[:i], templated[i + n :]
+    raise RuntimeError(f"Could not locate sentinel ids {sentinel_ids} in templated ids {templated}")
+
+
+def _build_pair_ids(
+    chat_prefix_ids: list[int],
+    chat_suffix_ids: list[int],
+    base_ids: list[int],
+    tokenizer,
+    chunks: list[str],
+    prompt_tokens: int,
+    cached_tokens: int,
+    rng: random.Random,
+) -> list[int]:
+    chat_overhead = len(chat_prefix_ids) + len(chat_suffix_ids)
+    if prompt_tokens < chat_overhead:
+        raise ValueError(f"prompt_tokens {prompt_tokens} is smaller than chat overhead {chat_overhead}")
+    if cached_tokens > prompt_tokens:
+        raise ValueError(f"cached_tokens {cached_tokens} exceeds prompt_tokens {prompt_tokens}")
+
+    content_target = prompt_tokens - chat_overhead
+    shared_content_len = max(0, cached_tokens - len(chat_prefix_ids))
+    shared_content_len = min(shared_content_len, content_target)
+
+    if shared_content_len > len(base_ids):
+        raise ValueError(f"shared_content_len {shared_content_len} exceeds base_ids length {len(base_ids)}")
+
+    shared = base_ids[:shared_content_len]
+    need_random = content_target - shared_content_len
+    random_ids = _build_random_suffix_ids(tokenizer, chunks, need_random, rng)
+    content = shared + random_ids
+    if len(content) < content_target:
+        raise RuntimeError(f"Could not build {content_target} content tokens from dataset (got {len(content)})")
+
+    return chat_prefix_ids + content[:content_target] + chat_suffix_ids
+
+
 class TranslationDataset:
+    """Build exact token-id prompts with a deterministic shared prefix."""
+
     def __init__(
         self,
         path: str,
@@ -185,46 +279,35 @@ class TranslationDataset:
         chat: bool,
         num_tokens: int,
         common_tokens: int,
+        seed: int = 0,
     ):
+        del prompt  # legacy arg; strict prompts are built from token ids only
         self._tokenizer = tokenizer
-        self._tokenizer_path = tokenizer_path
         self._num_tokens = num_tokens
-
-        self._all_limericks = []
-        with open(path, "r") as f:
-            text = f.read()
-            lims = text.split("\n\n")
-            for i, lim in enumerate(lims):
-                num_tokens = len(self._tokenizer.encode(lim, add_special_tokens=False))
-                self._all_limericks.append((lim, num_tokens))
-
-        self._prefix = ""
-        self._suffix = prompt
-        self._prefix_suffix_tokens = len(self._tokenizer.encode(prompt, add_special_tokens=False))
-        # Use deterministic selection (sequential iteration) to ensure all workers
-        # get the same prefix for the same common_tokens value
-        idx = 0
-        while self._prefix_suffix_tokens < common_tokens:
-            lim, num_tokens = self._all_limericks[idx % len(self._all_limericks)]
-            self._prefix += lim + "\n\n"
-            self._prefix_suffix_tokens += num_tokens
-            idx += 1
-
+        self._cached_tokens = min(common_tokens, num_tokens)
+        self._rng = random.Random(seed)
+        chunks = _load_chunks(path)
+        self._chunks = chunks
+        self._base_ids = _build_ids_to_length(tokenizer, chunks, num_tokens)
         if chat:
-            empty_template_tokens = empty_chat_template_token_ids(self._tokenizer, self._tokenizer_path)
-            self._prefix_suffix_tokens += len(empty_template_tokens)
+            model_type = resolve_model_type(tokenizer_path)
+            self._chat_prefix, self._chat_suffix = _split_chat_template(tokenizer, tokenizer_path, model_type)
+        else:
+            self._chat_prefix, self._chat_suffix = [], []
 
     def __next__(self):
-        prompt_tokens = self._prefix_suffix_tokens
-        prompt = self._prefix
-        while prompt_tokens < self._num_tokens:
-            lim, num_tokens = self._all_limericks[random.randint(0, len(self._all_limericks) - 1)]
-
-            prompt += lim + "\n\n"
-            prompt_tokens += num_tokens
-        prompt += self._suffix
-
-        return prompt, prompt_tokens
+        ids = _build_pair_ids(
+            self._chat_prefix,
+            self._chat_suffix,
+            self._base_ids,
+            self._tokenizer,
+            self._chunks,
+            self._num_tokens,
+            self._cached_tokens,
+            self._rng,
+        )
+        assert len(ids) == self._num_tokens
+        return ids, self._num_tokens
 
     def __iter__(self):
         return self
@@ -746,11 +829,14 @@ class BaseProvider(abc.ABC):
 
 
 class OpenAIProvider(BaseProvider):
-    def get_url(self):
+    def get_url(self, prompt=None):
         if self.parsed_options.rerank:
             return "/v1/rerank"
         elif self.parsed_options.embeddings:
             return "/v1/embeddings"
+        elif isinstance(prompt, list) and prompt and isinstance(prompt[0], int):
+            # Chat template is applied client-side; token ids go to /v1/completions.
+            return "/v1/completions"
         elif self.parsed_options.chat:
             return "/v1/chat/completions"
         else:
@@ -805,7 +891,11 @@ class OpenAIProvider(BaseProvider):
             data["logprobs"] = self.parsed_options.logprobs
         if self.parsed_options.reasoning_effort is not None:
             data["reasoning_effort"] = self.parsed_options.reasoning_effort
-        if isinstance(prompt, str):
+        if isinstance(prompt, list) and prompt and isinstance(prompt[0], int):
+            if images is not None:
+                raise ValueError("images are not supported with token-id prompts")
+            data["prompt"] = prompt
+        elif isinstance(prompt, str):
             if self.parsed_options.chat:
                 if images is None:
                     data["messages"] = [{"role": "user", "content": prompt}]
@@ -943,12 +1033,13 @@ class FireworksProvider(OpenAIProvider):
             self._forced_generation_pool = itertools.cycle(self._load_forced_generation_texts(forced_gen_path))
         elif forced_gen_from_dataset:
             assert parsed_options.tokenizer is not None, "--tokenizer is required for --forced-generation-from-dataset"
+            tokenizer = InitTracker.load_tokenizer(parsed_options.tokenizer)
             ds = DatasetHolder.get_forced_generation_instance(
                 dataset=parsed_options.dataset,
                 tokenizer=parsed_options.tokenizer,
                 max_tokens=parsed_options.max_tokens,
             )
-            self._forced_generation_pool = (text for text, _tokens in ds)
+            self._forced_generation_pool = (tokenizer.decode(ids) for ids, _tokens in ds)
         else:
             self._forced_generation_pool = None
 
@@ -1338,6 +1429,11 @@ class LLMUser(HttpUser):
                 # e.g., <|image|> for Phi, <|image_pad|> for Qwen, <image> for Llava
                 # So using /completions endpoint requires a bit more work to support this
                 raise AssertionError("--prompt-images-with-resolutions is only supported with --chat mode.")
+            if self.environment.parsed_options.dataset in ("limericks", "code"):
+                raise AssertionError(
+                    "--prompt-images-with-resolutions is not supported with limericks/code datasets "
+                    "(strict token-id prompts)."
+                )
             self.prompt_images = [self._create_base64_image(width, height) for width, height in image_resolutions]
 
         self.max_tokens_sampler = LengthSampler(
@@ -1409,7 +1505,11 @@ class LLMUser(HttpUser):
         self.dataset = iter(dataset)
 
         tokenizer = InitTracker.load_tokenizer(self.environment.parsed_options.tokenizer)
-        self.prompt_tokenizer_tokens = len(tokenizer.encode(self._get_input()[0]))
+        sample_prompt = self._get_input()[0]
+        if isinstance(sample_prompt, list):
+            self.prompt_tokenizer_tokens = len(sample_prompt)
+        else:
+            self.prompt_tokenizer_tokens = len(tokenizer.encode(sample_prompt))
 
         # Override dataset with synthetic rerank documents if num_documents or tokens_per_document is set
         if self.environment.parsed_options.rerank and (
@@ -1517,7 +1617,7 @@ class LLMUser(HttpUser):
         t_start = time.perf_counter()
 
         with self.client.post(
-            self.provider_formatter.get_url(),
+            self.provider_formatter.get_url(prompt),
             data=json.dumps(data),
             stream=True,
             catch_response=True,

--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -26,6 +26,8 @@ import re
 import gevent
 from locust.util.timespan import parse_timespan as _locust_parse_timespan
 
+from prefill_load_test import build_ids_to_length, build_pair_ids, load_chunks, split_chat_template
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
@@ -175,105 +177,12 @@ PROMPT_PREFIX_TOKEN = "Pad "  # exactly one token
 PROMPT_CHAT_IMAGE_PLACEHOLDER = "<image>"
 
 
-def _load_chunks(path: str) -> list[str]:
-    with open(path, "r") as f:
-        text = f.read()
-    chunks = [p for p in text.split("\n\n") if p.strip()]
-    if not chunks:
-        raise ValueError(f"No chunks in {path}")
-    return chunks
-
-
-def _build_ids_to_length(tokenizer, chunks: list[str], target_len: int) -> list[int]:
-    ids: list[int] = []
-    i = 0
-    while len(ids) < target_len and i < 1_000_000:
-        lim = chunks[i % len(chunks)]
-        ids.extend(tokenizer.encode(lim + "\n\n", add_special_tokens=False))
-        i += 1
-    return ids[:target_len]
-
-
-def _build_random_suffix_ids(
-    tokenizer, chunks: list[str], need_len: int, rng: random.Random
-) -> list[int]:
-    if need_len <= 0:
-        return []
-    ids: list[int] = []
-    i = 0
-    while len(ids) < need_len and i < 1_000_000:
-        lim = rng.choice(chunks)
-        ids.extend(tokenizer.encode(lim + "\n\n", add_special_tokens=False))
-        i += 1
-    return ids[:need_len]
-
-
-def _split_chat_template(
-    tokenizer, tokenizer_path: str, model_type: str
-) -> tuple[list[int], list[int]]:
-    sentinel = "abcdefghij"
-    sentinel_ids = _normalize_token_ids(tokenizer.encode(sentinel, add_special_tokens=False))
-    if not sentinel_ids:
-        raise RuntimeError("Sentinel tokenized to empty id list; cannot split chat template.")
-    if model_type == "deepseek_v4":
-        encode_messages = load_dsv4_encode_messages(tokenizer_path)
-        prompt = encode_messages([{"role": "user", "content": sentinel}], thinking_mode="chat")
-        templated = _normalize_token_ids(tokenizer.encode(prompt, add_special_tokens=False))
-    else:
-        templated = _normalize_token_ids(
-            tokenizer.apply_chat_template(
-                [{"role": "user", "content": sentinel}],
-                tokenize=True,
-                add_generation_prompt=True,
-            )
-        )
-    n = len(sentinel_ids)
-    for i in range(len(templated) - n + 1):
-        if templated[i : i + n] == sentinel_ids:
-            return templated[:i], templated[i + n :]
-    raise RuntimeError(f"Could not locate sentinel ids {sentinel_ids} in templated ids {templated}")
-
-
-def _build_pair_ids(
-    chat_prefix_ids: list[int],
-    chat_suffix_ids: list[int],
-    base_ids: list[int],
-    tokenizer,
-    chunks: list[str],
-    prompt_tokens: int,
-    cached_tokens: int,
-    rng: random.Random,
-) -> list[int]:
-    chat_overhead = len(chat_prefix_ids) + len(chat_suffix_ids)
-    if prompt_tokens < chat_overhead:
-        raise ValueError(f"prompt_tokens {prompt_tokens} is smaller than chat overhead {chat_overhead}")
-    if cached_tokens > prompt_tokens:
-        raise ValueError(f"cached_tokens {cached_tokens} exceeds prompt_tokens {prompt_tokens}")
-
-    content_target = prompt_tokens - chat_overhead
-    shared_content_len = max(0, cached_tokens - len(chat_prefix_ids))
-    shared_content_len = min(shared_content_len, content_target)
-
-    if shared_content_len > len(base_ids):
-        raise ValueError(f"shared_content_len {shared_content_len} exceeds base_ids length {len(base_ids)}")
-
-    shared = base_ids[:shared_content_len]
-    need_random = content_target - shared_content_len
-    random_ids = _build_random_suffix_ids(tokenizer, chunks, need_random, rng)
-    content = shared + random_ids
-    if len(content) < content_target:
-        raise RuntimeError(f"Could not build {content_target} content tokens from dataset (got {len(content)})")
-
-    return chat_prefix_ids + content[:content_target] + chat_suffix_ids
-
-
 class TranslationDataset:
     """Build exact token-id prompts with a deterministic shared prefix."""
 
     def __init__(
         self,
-        path: str,
-        prompt: str,
+        dataset: str,
         tokenizer,
         tokenizer_path: str,
         chat: bool,
@@ -281,22 +190,20 @@ class TranslationDataset:
         common_tokens: int,
         seed: int = 0,
     ):
-        del prompt  # legacy arg; strict prompts are built from token ids only
         self._tokenizer = tokenizer
         self._num_tokens = num_tokens
         self._cached_tokens = min(common_tokens, num_tokens)
         self._rng = random.Random(seed)
-        chunks = _load_chunks(path)
-        self._chunks = chunks
-        self._base_ids = _build_ids_to_length(tokenizer, chunks, num_tokens)
+        self._chunks = load_chunks(dataset)
+        self._base_ids = build_ids_to_length(tokenizer, self._chunks, num_tokens)
         if chat:
             model_type = resolve_model_type(tokenizer_path)
-            self._chat_prefix, self._chat_suffix = _split_chat_template(tokenizer, tokenizer_path, model_type)
+            self._chat_prefix, self._chat_suffix = split_chat_template(tokenizer, tokenizer_path, model_type)
         else:
             self._chat_prefix, self._chat_suffix = [], []
 
     def __next__(self):
-        ids = _build_pair_ids(
+        ids = build_pair_ids(
             self._chat_prefix,
             self._chat_suffix,
             self._base_ids,
@@ -363,26 +270,12 @@ class DatasetHolder:
                 dataset_limit=getattr(options, "dataset_limit", None),
             )
         elif options.dataset in ("limericks", "code"):
-            if options.dataset == "limericks":
-                if options.prompt is None:
-                    prompt = "Translate the limericks above to Spanish."
-                else:
-                    prompt = options.prompt
-                dataset_file = "limericks.txt"
-            elif options.dataset == "code":
-                if options.prompt is None:
-                    prompt = "Translate the code above to C++."
-                else:
-                    prompt = options.prompt
-                dataset_file = "code.txt"
-
             common_tokens = options.prompt_cache_max_len
             if common_tokens > options.prompt_tokens:
                 common_tokens = options.prompt_tokens
             tokenizer_path = options.tokenizer or DEFAULT_TOKENIZER
             return TranslationDataset(
-                path=os.path.join(os.path.dirname(os.path.abspath(__file__)), dataset_file),
-                prompt="\n\n" + prompt,
+                dataset=options.dataset,
                 tokenizer=InitTracker.load_tokenizer(options.tokenizer),
                 tokenizer_path=tokenizer_path,
                 chat=options.chat and not getattr(options, "rerank", False),
@@ -406,16 +299,13 @@ class DatasetHolder:
                     "--forced-generation-from-dataset only works with 'limericks' or 'code' datasets, "
                     "not JSONL files. Use --forced-generation-file instead."
                 )
-            dataset_files = {"limericks": "limericks.txt", "code": "code.txt"}
-            if dataset not in dataset_files:
+            if dataset not in ("limericks", "code"):
                 raise ValueError(
                     f"--forced-generation-from-dataset requires --dataset to be one of "
-                    f"{list(dataset_files.keys())}, got '{dataset}'"
+                    f"['limericks', 'code'], got '{dataset}'"
                 )
-            path = os.path.join(os.path.dirname(os.path.abspath(__file__)), dataset_files[dataset])
             cls._forced_generation_instance = TranslationDataset(
-                path=path,
-                prompt="",
+                dataset=dataset,
                 tokenizer=InitTracker.load_tokenizer(tokenizer),
                 tokenizer_path=tokenizer or DEFAULT_TOKENIZER,
                 chat=False,
@@ -829,14 +719,11 @@ class BaseProvider(abc.ABC):
 
 
 class OpenAIProvider(BaseProvider):
-    def get_url(self, prompt=None):
+    def get_url(self):
         if self.parsed_options.rerank:
             return "/v1/rerank"
         elif self.parsed_options.embeddings:
             return "/v1/embeddings"
-        elif isinstance(prompt, list) and prompt and isinstance(prompt[0], int):
-            # Chat template is applied client-side; token ids go to /v1/completions.
-            return "/v1/completions"
         elif self.parsed_options.chat:
             return "/v1/chat/completions"
         else:
@@ -1616,8 +1503,13 @@ class LLMUser(HttpUser):
             print("---")
         t_start = time.perf_counter()
 
+        url = self.provider_formatter.get_url()
+        # Chat template is applied client-side; token ids always use /v1/completions.
+        if isinstance(prompt, list) and prompt and isinstance(prompt[0], int):
+            url = "/v1/completions"
+
         with self.client.post(
-            self.provider_formatter.get_url(prompt),
+            url,
             data=json.dumps(data),
             stream=True,
             catch_response=True,

--- a/llm_bench/test_load_test_strict.py
+++ b/llm_bench/test_load_test_strict.py
@@ -7,7 +7,8 @@ from unittest import mock
 
 import transformers
 
-from load_test import TranslationDataset, _build_pair_ids, _load_chunks
+from load_test import TranslationDataset
+from prefill_load_test import build_pair_ids, load_chunks
 
 
 class StrictPromptTests(unittest.TestCase):
@@ -16,15 +17,11 @@ class StrictPromptTests(unittest.TestCase):
         cls.tokenizer = transformers.AutoTokenizer.from_pretrained("gpt2")
         cls.tokenizer.add_bos_token = False
         cls.tokenizer.add_eos_token = False
-        cls.path = __import__("os").path.join(
-            __import__("os").path.dirname(__import__("os").path.abspath(__file__)), "limericks.txt"
-        )
-        cls.chunks = _load_chunks(cls.path)
+        cls.chunks = load_chunks("limericks")
 
     def test_exact_prompt_length_no_chat(self):
         ds = TranslationDataset(
-            path=self.path,
-            prompt="",
+            dataset="limericks",
             tokenizer=self.tokenizer,
             tokenizer_path="gpt2",
             chat=False,
@@ -33,18 +30,16 @@ class StrictPromptTests(unittest.TestCase):
             seed=1,
         )
         ids, reported = next(iter(ds))
-        self.assertIsInstance(ids, list)
         self.assertEqual(reported, 512)
         self.assertEqual(len(ids), 512)
 
     def test_exact_prompt_length_with_chat(self):
         fake_prefix, fake_suffix = [1, 2, 3], [4, 5]
         with mock.patch("load_test.resolve_model_type", return_value="gpt2"), mock.patch(
-            "load_test._split_chat_template", return_value=(fake_prefix, fake_suffix)
+            "load_test.split_chat_template", return_value=(fake_prefix, fake_suffix)
         ):
             ds = TranslationDataset(
-                path=self.path,
-                prompt="",
+                dataset="limericks",
                 tokenizer=self.tokenizer,
                 tokenizer_path="gpt2",
                 chat=True,
@@ -54,55 +49,29 @@ class StrictPromptTests(unittest.TestCase):
             )
             ids, reported = next(iter(ds))
         self.assertEqual(len(ids), 512)
-        self.assertEqual(reported, 512)
         self.assertEqual(ids[:3], fake_prefix)
         self.assertEqual(ids[-2:], fake_suffix)
 
     def test_shared_prefix_matches_cached_tokens(self):
-        prompt_tokens = 1000
-        cached_tokens = 600
         ds = TranslationDataset(
-            path=self.path,
-            prompt="",
+            dataset="limericks",
             tokenizer=self.tokenizer,
             tokenizer_path="gpt2",
             chat=False,
-            num_tokens=prompt_tokens,
-            common_tokens=cached_tokens,
+            num_tokens=1000,
+            common_tokens=600,
             seed=3,
         )
         first, _ = next(iter(ds))
         second, _ = next(iter(ds))
-        self.assertEqual(first[:cached_tokens], second[:cached_tokens])
+        self.assertEqual(first[:600], second[:600])
         self.assertNotEqual(first, second)
 
-    def test_shared_prefix_with_chat_template(self):
-        prompt_tokens = 800
-        cached_tokens = 400
-        prefix, suffix = [11, 12, 13], [21, 22]
-        rng = random.Random(4)
-        base_ids = [i % 1000 for i in range(prompt_tokens)]
-        a = _build_pair_ids(prefix, suffix, base_ids, self.tokenizer, self.chunks, prompt_tokens, cached_tokens, rng)
-        b = _build_pair_ids(prefix, suffix, base_ids, self.tokenizer, self.chunks, prompt_tokens, cached_tokens, rng)
-        self.assertEqual(len(a), prompt_tokens)
-        self.assertEqual(len(b), prompt_tokens)
-        self.assertEqual(a[:cached_tokens], b[:cached_tokens])
-
-    def test_openai_provider_token_ids_use_completions(self):
-        from load_test import OpenAIProvider
-
-        opts = mock.Mock(chat=True, rerank=False, embeddings=False)
-        provider = OpenAIProvider("test-model", opts)
-        self.assertEqual(provider.get_url([1, 2, 3]), "/v1/completions")
-        self.assertEqual(provider.get_url("hello"), "/v1/chat/completions")
-
     def test_per75_shape_shared_prefix(self):
-        """Scaled-down check: first cached_tokens ids are identical across requests."""
         prompt_tokens = 5000
-        cached_tokens = 3750  # 75% of 5000, mirrors deployment experiment ratio
+        cached_tokens = 3750
         ds = TranslationDataset(
-            path=self.path,
-            prompt="",
+            dataset="limericks",
             tokenizer=self.tokenizer,
             tokenizer_path="gpt2",
             chat=False,
@@ -111,10 +80,9 @@ class StrictPromptTests(unittest.TestCase):
             seed=99,
         )
         prompts = [next(iter(ds))[0] for _ in range(5)]
-        for p in prompts:
-            self.assertEqual(len(p), prompt_tokens)
         prefix = prompts[0][:cached_tokens]
         for p in prompts[1:]:
+            self.assertEqual(len(p), prompt_tokens)
             self.assertEqual(p[:cached_tokens], prefix)
             self.assertNotEqual(p, prompts[0])
 

--- a/llm_bench/test_load_test_strict.py
+++ b/llm_bench/test_load_test_strict.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Unit tests for strict token-id prompt construction in load_test.py."""
+
+import random
+import unittest
+from unittest import mock
+
+import transformers
+
+from load_test import TranslationDataset, _build_pair_ids, _load_chunks
+
+
+class StrictPromptTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tokenizer = transformers.AutoTokenizer.from_pretrained("gpt2")
+        cls.tokenizer.add_bos_token = False
+        cls.tokenizer.add_eos_token = False
+        cls.path = __import__("os").path.join(
+            __import__("os").path.dirname(__import__("os").path.abspath(__file__)), "limericks.txt"
+        )
+        cls.chunks = _load_chunks(cls.path)
+
+    def test_exact_prompt_length_no_chat(self):
+        ds = TranslationDataset(
+            path=self.path,
+            prompt="",
+            tokenizer=self.tokenizer,
+            tokenizer_path="gpt2",
+            chat=False,
+            num_tokens=512,
+            common_tokens=0,
+            seed=1,
+        )
+        ids, reported = next(iter(ds))
+        self.assertIsInstance(ids, list)
+        self.assertEqual(reported, 512)
+        self.assertEqual(len(ids), 512)
+
+    def test_exact_prompt_length_with_chat(self):
+        fake_prefix, fake_suffix = [1, 2, 3], [4, 5]
+        with mock.patch("load_test.resolve_model_type", return_value="gpt2"), mock.patch(
+            "load_test._split_chat_template", return_value=(fake_prefix, fake_suffix)
+        ):
+            ds = TranslationDataset(
+                path=self.path,
+                prompt="",
+                tokenizer=self.tokenizer,
+                tokenizer_path="gpt2",
+                chat=True,
+                num_tokens=512,
+                common_tokens=0,
+                seed=2,
+            )
+            ids, reported = next(iter(ds))
+        self.assertEqual(len(ids), 512)
+        self.assertEqual(reported, 512)
+        self.assertEqual(ids[:3], fake_prefix)
+        self.assertEqual(ids[-2:], fake_suffix)
+
+    def test_shared_prefix_matches_cached_tokens(self):
+        prompt_tokens = 1000
+        cached_tokens = 600
+        ds = TranslationDataset(
+            path=self.path,
+            prompt="",
+            tokenizer=self.tokenizer,
+            tokenizer_path="gpt2",
+            chat=False,
+            num_tokens=prompt_tokens,
+            common_tokens=cached_tokens,
+            seed=3,
+        )
+        first, _ = next(iter(ds))
+        second, _ = next(iter(ds))
+        self.assertEqual(first[:cached_tokens], second[:cached_tokens])
+        self.assertNotEqual(first, second)
+
+    def test_shared_prefix_with_chat_template(self):
+        prompt_tokens = 800
+        cached_tokens = 400
+        prefix, suffix = [11, 12, 13], [21, 22]
+        rng = random.Random(4)
+        base_ids = [i % 1000 for i in range(prompt_tokens)]
+        a = _build_pair_ids(prefix, suffix, base_ids, self.tokenizer, self.chunks, prompt_tokens, cached_tokens, rng)
+        b = _build_pair_ids(prefix, suffix, base_ids, self.tokenizer, self.chunks, prompt_tokens, cached_tokens, rng)
+        self.assertEqual(len(a), prompt_tokens)
+        self.assertEqual(len(b), prompt_tokens)
+        self.assertEqual(a[:cached_tokens], b[:cached_tokens])
+
+    def test_openai_provider_token_ids_use_completions(self):
+        from load_test import OpenAIProvider
+
+        opts = mock.Mock(chat=True, rerank=False, embeddings=False)
+        provider = OpenAIProvider("test-model", opts)
+        self.assertEqual(provider.get_url([1, 2, 3]), "/v1/completions")
+        self.assertEqual(provider.get_url("hello"), "/v1/chat/completions")
+
+    def test_per75_shape_shared_prefix(self):
+        """Scaled-down check: first cached_tokens ids are identical across requests."""
+        prompt_tokens = 5000
+        cached_tokens = 3750  # 75% of 5000, mirrors deployment experiment ratio
+        ds = TranslationDataset(
+            path=self.path,
+            prompt="",
+            tokenizer=self.tokenizer,
+            tokenizer_path="gpt2",
+            chat=False,
+            num_tokens=prompt_tokens,
+            common_tokens=cached_tokens,
+            seed=99,
+        )
+        prompts = [next(iter(ds))[0] for _ in range(5)]
+        for p in prompts:
+            self.assertEqual(len(p), prompt_tokens)
+        prefix = prompts[0][:cached_tokens]
+        for p in prompts[1:]:
+            self.assertEqual(p[:cached_tokens], prefix)
+            self.assertNotEqual(p, prompts[0])
+
+    def test_format_payload_accepts_token_ids(self):
+        from load_test import OpenAIProvider
+
+        opts = mock.Mock(
+            chat=True,
+            rerank=False,
+            embeddings=False,
+            stream=False,
+            temperature=1.0,
+            n=1,
+            top_k=None,
+            logprobs=None,
+            reasoning_effort=None,
+            clear_assistant=False,
+        )
+        provider = OpenAIProvider("test-model", opts)
+        payload = provider.format_payload([10, 20, 30], max_tokens=16, images=None)
+        self.assertEqual(payload["prompt"], [10, 20, 30])
+        self.assertNotIn("messages", payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `load_test.py` unconditionally strict for limericks/code datasets: prompts are built as exact token-id sequences with a deterministic shared prefix, reusing `build_pair_ids` / `split_chat_template` from `prefill_load_test.py`.

Deployment experiments were configured for 75% cache hit (`--prompt-cache-max-len=37500` on 50k prompts) but measured ~58% because `TranslationDataset` estimated token counts from text chunks instead of enforcing shareable prefix token IDs.

## Changes

- **`TranslationDataset`**: uses `prefill_load_test` helpers — exact `len(prompt) == prompt_tokens`, first `cached_tokens` IDs identical across requests
- **Request path**: token-id prompts go to `/v1/completions` (chat template applied client-side); URL routing done inline in `_do_generate_text` so other providers' `get_url()` signatures are unchanged
- **`OpenAIProvider`**: handles `list[int]` prompts in `format_payload`
- **Forced generation from dataset**: decodes token ids to text for the `forced_generation` field
- **Incompatibility**: `--prompt-images-with-resolutions` + limericks/code raises at startup

## Bugbot fix

Previous version passed `prompt` to `get_url()`, which broke `TogetherProvider`, `TgiProvider`, and Triton providers (they override `get_url(self)` with no extra parameter). Fixed by selecting `/v1/completions` inline when the prompt is a token-id list.

## What this fixes vs follow-up

| Fixed | Follow-up (not in this PR) |
| --- | --- |
| Exact prompt lengths | KV cache warmup (`cached_tokens + 1`) |
| `prompt_cache_max_len` = shareable prefix semantics | Per-worker cache priming under LB |
| DSV4-safe via `split_chat_template` / `encode_messages` |

## Testing

```bash
cd llm_bench && python3 -m unittest test_load_test_strict.py -v
```

All 5 tests pass.

**Suggested validation on cluster**: re-run the DSV4 deployment experiment (`--prompt-cache-max-len=37500`, 50k prompt) and confirm measured cache hit ≈ 75% (modulo warmup).
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://fireworks-ai.slack.com/archives/C0B5RNF0PN0/p1780501645454689?thread_ts=1780501645.454689&cid=C0B5RNF0PN0)

<div><a href="https://cursor.com/agents/bc-60e1fc6a-c65c-54a7-99ef-74547d79bdbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60e1fc6a-c65c-54a7-99ef-74547d79bdbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

