### PR TITLE
Make load_test.py unconditionally strict for limericks/code

### DIFF
--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -26,6 +26,8 @@ import re
 import gevent
 from locust.util.timespan import parse_timespan as _locust_parse_timespan
 
+from prefill_load_test import build_ids_to_length, build_pair_ids, load_chunks, split_chat_template
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
@@ -185,46 +187,81 @@ class TranslationDataset:
         chat: bool,
         num_tokens: int,
         common_tokens: int,
+        strict: bool = True,
+        seed: int = 0,
     ):
+        self._strict = strict
         self._tokenizer = tokenizer
         self._tokenizer_path = tokenizer_path
         self._num_tokens = num_tokens
 
-        self._all_limericks = []
-        with open(path, "r") as f:
-            text = f.read()
-            lims = text.split("\n\n")
-            for i, lim in enumerate(lims):
-                num_tokens = len(self._tokenizer.encode(lim, add_special_tokens=False))
-                self._all_limericks.append((lim, num_tokens))
+        if not strict:
+            self._all_limericks = []
+            with open(path, "r") as f:
+                text = f.read()
+                lims = text.split("\n\n")
+                for i, lim in enumerate(lims):
+                    lim_tokens = len(self._tokenizer.encode(lim, add_special_tokens=False))
+                    self._all_limericks.append((lim, lim_tokens))
 
-        self._prefix = ""
-        self._suffix = prompt
-        self._prefix_suffix_tokens = len(self._tokenizer.encode(prompt, add_special_tokens=False))
-        # Use deterministic selection (sequential iteration) to ensure all workers
-        # get the same prefix for the same common_tokens value
-        idx = 0
-        while self._prefix_suffix_tokens < common_tokens:
-            lim, num_tokens = self._all_limericks[idx % len(self._all_limericks)]
-            self._prefix += lim + "\n\n"
-            self._prefix_suffix_tokens += num_tokens
-            idx += 1
+            self._prefix = ""
+            self._suffix = prompt
+            self._prefix_suffix_tokens = len(self._tokenizer.encode(prompt, add_special_tokens=False))
+            # Use deterministic selection (sequential iteration) to ensure all workers
+            # get the same prefix for the same common_tokens value
+            idx = 0
+            while self._prefix_suffix_tokens < common_tokens:
+                lim, lim_tokens = self._all_limericks[idx % len(self._all_limericks)]
+                self._prefix += lim + "\n\n"
+                self._prefix_suffix_tokens += lim_tokens
+                idx += 1
 
+            if chat:
+                empty_template_tokens = empty_chat_template_token_ids(self._tokenizer, self._tokenizer_path)
+                self._prefix_suffix_tokens += len(empty_template_tokens)
+            return
+
+        dataset = os.path.basename(path).removesuffix(".txt")
+        self._cached_tokens = min(common_tokens, num_tokens)
+        self._rng = random.Random(seed)
+        self._chunks = load_chunks(dataset)
+        self._base_ids = build_ids_to_length(tokenizer, self._chunks, num_tokens)
+        self._instruction_ids = tokenizer.encode(prompt, add_special_tokens=False) if prompt else []
         if chat:
-            empty_template_tokens = empty_chat_template_token_ids(self._tokenizer, self._tokenizer_path)
-            self._prefix_suffix_tokens += len(empty_template_tokens)
+            model_type = resolve_model_type(tokenizer_path)
+            self._chat_prefix, self._chat_suffix = split_chat_template(tokenizer, tokenizer_path, model_type)
+        else:
+            self._chat_prefix, self._chat_suffix = [], []
 
     def __next__(self):
-        prompt_tokens = self._prefix_suffix_tokens
-        prompt = self._prefix
-        while prompt_tokens < self._num_tokens:
-            lim, num_tokens = self._all_limericks[random.randint(0, len(self._all_limericks) - 1)]
+        if not self._strict:
+            prompt_tokens = self._prefix_suffix_tokens
+            prompt = self._prefix
+            while prompt_tokens < self._num_tokens:
+                lim, lim_tokens = self._all_limericks[random.randint(0, len(self._all_limericks) - 1)]
+                prompt += lim + "\n\n"
+                prompt_tokens += lim_tokens
+            prompt += self._suffix
+            return prompt, prompt_tokens
 
-            prompt += lim + "\n\n"
-            prompt_tokens += num_tokens
-        prompt += self._suffix
-
-        return prompt, prompt_tokens
+        body_tokens = self._num_tokens - len(self._instruction_ids)
+        ids = build_pair_ids(
+            self._chat_prefix,
+            self._chat_suffix,
+            self._base_ids,
+            self._tokenizer,
+            self._chunks,
+            body_tokens,
+            self._cached_tokens,
+            self._rng,
+        )
+        if self._instruction_ids:
+            if self._chat_suffix:
+                ids = ids[: -len(self._chat_suffix)] + self._instruction_ids + self._chat_suffix
+            else:
+                ids = ids + self._instruction_ids
+        assert len(ids) == self._num_tokens
+        return ids, self._num_tokens
 
     def __iter__(self):
         return self
@@ -305,6 +342,7 @@ class DatasetHolder:
                 chat=options.chat and not getattr(options, "rerank", False),
                 num_tokens=options.prompt_tokens,
                 common_tokens=common_tokens,
+                strict=not getattr(options, "rerank", False),
             )
         else:
             raise ValueError(f"Unknown dataset: {options.dataset}")
@@ -758,7 +796,7 @@ class OpenAIProvider(BaseProvider):
 
     def format_payload(self, prompt, max_tokens, images):
         if self.parsed_options.rerank:
-            if isinstance(prompt, list):
+            if isinstance(prompt, list) and prompt and isinstance(prompt[0], str):
                 documents = prompt
             else:
                 documents = [doc.strip() for doc in prompt.split("\n\n") if doc.strip()]
@@ -805,7 +843,11 @@ class OpenAIProvider(BaseProvider):
             data["logprobs"] = self.parsed_options.logprobs
         if self.parsed_options.reasoning_effort is not None:
             data["reasoning_effort"] = self.parsed_options.reasoning_effort
-        if isinstance(prompt, str):
+        if isinstance(prompt, list) and prompt and isinstance(prompt[0], int):
+            if images is not None:
+                raise ValueError("images are not supported with token-id prompts")
+            data["prompt"] = prompt
+        elif isinstance(prompt, str):
             if self.parsed_options.chat:
                 if images is None:
                     data["messages"] = [{"role": "user", "content": prompt}]
@@ -943,12 +985,13 @@ class FireworksProvider(OpenAIProvider):
             self._forced_generation_pool = itertools.cycle(self._load_forced_generation_texts(forced_gen_path))
         elif forced_gen_from_dataset:
             assert parsed_options.tokenizer is not None, "--tokenizer is required for --forced-generation-from-dataset"
+            tokenizer = InitTracker.load_tokenizer(parsed_options.tokenizer)
             ds = DatasetHolder.get_forced_generation_instance(
                 dataset=parsed_options.dataset,
                 tokenizer=parsed_options.tokenizer,
                 max_tokens=parsed_options.max_tokens,
             )
-            self._forced_generation_pool = (text for text, _tokens in ds)
+            self._forced_generation_pool = (tokenizer.decode(ids) for ids, _tokens in ds)
         else:
             self._forced_generation_pool = None
 
@@ -1409,7 +1452,11 @@ class LLMUser(HttpUser):
         self.dataset = iter(dataset)
 
         tokenizer = InitTracker.load_tokenizer(self.environment.parsed_options.tokenizer)
-        self.prompt_tokenizer_tokens = len(tokenizer.encode(self._get_input()[0]))
+        sample_prompt = self._get_input()[0]
+        if isinstance(sample_prompt, list):
+            self.prompt_tokenizer_tokens = len(sample_prompt)
+        else:
+            self.prompt_tokenizer_tokens = len(tokenizer.encode(sample_prompt))
 
         # Override dataset with synthetic rerank documents if num_documents or tokens_per_document is set
         if self.environment.parsed_options.rerank and (
@@ -1516,8 +1563,12 @@ class LLMUser(HttpUser):
             print("---")
         t_start = time.perf_counter()
 
+        url = self.provider_formatter.get_url()
+        if isinstance(prompt, list) and prompt and isinstance(prompt[0], int):
+            url = "/v1/completions"
+
         with self.client.post(
-            self.provider_formatter.get_url(),
+            url,
             data=json.dumps(data),
             stream=True,
             catch_response=True,

--- a/llm_bench/test_load_test_strict.py
+++ b/llm_bench/test_load_test_strict.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Unit tests for strict token-id prompt construction in load_test.py."""
+
+import os
+import unittest
+from unittest import mock
+
+import transformers
+
+from load_test import OpenAIProvider, TranslationDataset
+from prefill_load_test import load_chunks
+
+
+class StrictPromptTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tokenizer = transformers.AutoTokenizer.from_pretrained("gpt2")
+        cls.tokenizer.add_bos_token = False
+        cls.tokenizer.add_eos_token = False
+        cls.limericks_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "limericks.txt")
+        cls.chunks = load_chunks("limericks")
+
+    def _make_dataset(self, **kwargs):
+        defaults = dict(
+            path=self.limericks_path,
+            prompt="\n\nTranslate the limericks above to Spanish.",
+            tokenizer=self.tokenizer,
+            tokenizer_path="gpt2",
+            chat=False,
+            num_tokens=512,
+            common_tokens=0,
+            strict=True,
+            seed=1,
+        )
+        defaults.update(kwargs)
+        return TranslationDataset(**defaults)
+
+    def test_exact_prompt_length_no_chat(self):
+        ds = self._make_dataset()
+        ids, reported = next(iter(ds))
+        self.assertEqual(reported, 512)
+        self.assertEqual(len(ids), 512)
+
+    def test_exact_prompt_length_with_chat(self):
+        fake_prefix, fake_suffix = [1, 2, 3], [4, 5]
+        with mock.patch("load_test.resolve_model_type", return_value="gpt2"), mock.patch(
+            "load_test.split_chat_template", return_value=(fake_prefix, fake_suffix)
+        ):
+            ds = self._make_dataset(chat=True, seed=2)
+            ids, reported = next(iter(ds))
+        self.assertEqual(len(ids), 512)
+        self.assertEqual(ids[:3], fake_prefix)
+        self.assertEqual(ids[-2:], fake_suffix)
+
+    def test_shared_prefix_matches_cached_tokens(self):
+        ds = self._make_dataset(num_tokens=1000, common_tokens=600, seed=3)
+        first, _ = next(iter(ds))
+        second, _ = next(iter(ds))
+        self.assertEqual(first[:600], second[:600])
+        self.assertNotEqual(first, second)
+
+    def test_per75_shape_shared_prefix(self):
+        prompt_tokens = 5000
+        cached_tokens = 3750
+        ds = self._make_dataset(num_tokens=prompt_tokens, common_tokens=cached_tokens, seed=99)
+        prompts = [next(iter(ds))[0] for _ in range(5)]
+        prefix = prompts[0][:cached_tokens]
+        for p in prompts[1:]:
+            self.assertEqual(len(p), prompt_tokens)
+            self.assertEqual(p[:cached_tokens], prefix)
+            self.assertNotEqual(p, prompts[0])
+
+    def test_custom_prompt_suffix_is_included(self):
+        custom = "\n\nDo something custom."
+        ds = self._make_dataset(prompt=custom, num_tokens=256, common_tokens=0, seed=4)
+        ids, _ = next(iter(ds))
+        instruction_ids = self.tokenizer.encode(custom, add_special_tokens=False)
+        self.assertEqual(ids[-len(instruction_ids) :], instruction_ids)
+
+    def test_rerank_uses_legacy_text_prompts(self):
+        ds = self._make_dataset(strict=False, num_tokens=200, common_tokens=50, seed=5)
+        prompt, reported = next(iter(ds))
+        self.assertIsInstance(prompt, str)
+        self.assertGreater(reported, 0)
+
+    def test_format_payload_accepts_token_ids(self):
+        opts = mock.Mock(
+            chat=True,
+            rerank=False,
+            embeddings=False,
+            stream=False,
+            temperature=1.0,
+            n=1,
+            top_k=None,
+            logprobs=None,
+            reasoning_effort=None,
+            clear_assistant=False,
+        )
+        provider = OpenAIProvider("test-model", opts)
+        payload = provider.format_payload([10, 20, 30], max_tokens=16, images=None)
+        self.assertEqual(payload["prompt"], [10, 20, 30])
+        self.assertNotIn("messages", payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes PER-75: deployment experiments were measuring ~58% cache hit vs 75% configured because `load_test.py` built approximate text prompts instead of exact token-id sequences.

`TranslationDataset` now always builds strict prompts for limericks/code (imports `build_pair_ids` from `prefill_load_test.py`). Only prompt construction and the minimal request-path wiring changed:

- Exact `len(prompt) == prompt_tokens`
- First `cached_tokens` IDs identical across requests
- `--prompt` custom instruction preserved as trailing instruction token ids
- Token ids → `/v1/completions` even with `--chat` (template applied client-side)
- Legacy text path kept **only** for `--rerank` (rerank needs paragraph-split strings)

## Test plan

- [x] `cd llm_bench && python3 -m unittest test_load_test_strict.py -v` (7 tests)
- [ ] Re-run DSV4 deployment experiment with `--prompt-cache-max-len=37500` — measured cache hit should approach 75% (warmup follow-up still needed for full hit rate)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://fireworks-ai.slack.com/archives/C0B5RNF0PN0/p1780501645454689?thread_ts=1780501645.454689&cid=C0B5RNF0PN0)

<div><a href="https://cursor.com/agents/bc-287d8617-0d34-5283-9180-93ebb42c7cec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-287d8617-0d34-5283-9180-93ebb42c7cec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

