### PR TITLE
feat(llm-bench): record Fireworks server perf metrics

### DIFF
--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -924,6 +924,26 @@ class FireworksProvider(OpenAIProvider):
         Only records speculation hit rates for generations with >= 30 tokens to ensure
         meaningful statistics.
         """
+        def get_perf_metric(name):
+            value = (perf_metrics or {}).get(name)
+            if value is None:
+                value = headers.get(f"fireworks-{name}")
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                return None
+
+        # FireAttention and fw-proxy expose these in seconds. Record them as
+        # Locust metrics in milliseconds so they use the same units as existing
+        # client-side latency rows.
+        server_processing_time = get_perf_metric("server-processing-time")
+        if server_processing_time is not None:
+            add_custom_metric("server_side_total_latency", server_processing_time * 1000)
+
+        server_ttft = get_perf_metric("server-time-to-first-token")
+        if server_ttft is not None:
+            add_custom_metric("server_side_time_to_first_token", server_ttft * 1000)
+
         # Only track speculation hit rates for sufficiently long generations
         if num_tokens is None or num_tokens < 30:
             return

--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -935,14 +935,20 @@ class FireworksProvider(OpenAIProvider):
 
         # FireAttention and fw-proxy expose these in seconds. Record them as
         # Locust metrics in milliseconds so they use the same units as existing
-        # client-side latency rows.
-        server_processing_time = get_perf_metric("server-processing-time")
-        if server_processing_time is not None:
-            add_custom_metric("server_side_total_latency", server_processing_time * 1000)
+        # client-side latency rows. This is best-effort: it runs before
+        # response.success() inside a catch_response block, so any failure here
+        # must never mark the request as failed or perturb the existing
+        # client-side tables.
+        try:
+            server_processing_time = get_perf_metric("server-processing-time")
+            if server_processing_time is not None:
+                add_custom_metric("server_side_total_latency", server_processing_time * 1000)
 
-        server_ttft = get_perf_metric("server-time-to-first-token")
-        if server_ttft is not None:
-            add_custom_metric("server_side_time_to_first_token", server_ttft * 1000)
+            server_ttft = get_perf_metric("server-time-to-first-token")
+            if server_ttft is not None:
+                add_custom_metric("server_side_time_to_first_token", server_ttft * 1000)
+        except Exception as e:
+            logger.debug(f"Skipping server-side perf metrics: {e}")
 
         # Only track speculation hit rates for sufficiently long generations
         if num_tokens is None or num_tokens < 30:


### PR DESCRIPTION
## Summary
- Record Fireworks server-side total latency and TTFT as Locust custom metrics when response `perf_metrics` or `fireworks-*` headers are present.
- Keep existing client-side Locust metrics unchanged.
- Preserve existing speculation hit-rate handling by recording the new metrics before the speculation-specific early return.

## Context
FireAttention and recent fw-proxy builds can expose server timing via response headers or streaming `perf_metrics`. This lets downstream load-test workflows add optional server-side response metrics without relying on Prometheus/GMP histogram windows.

## Testing
- [x] `python3 -m py_compile llm_bench/load_test.py`

## Notes
- Metrics are emitted in milliseconds to match existing Locust latency rows.
- If headers/perf metrics are absent, no new rows are emitted.

Made with [Cursor](https://cursor.com)