### PR TITLE
llm_bench: allow --reasoning-effort none

### DIFF
--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -1972,8 +1972,9 @@ def init_parser(parser):
         "--reasoning-effort",
         type=str,
         default=None,
-        choices=["low", "medium", "high"],
+        choices=["none", "low", "medium", "high"],
         help="Set the reasoning_effort parameter for the API request. "
+        "Use 'none' to disable thinking/reasoning where supported. "
         "If not specified and using a JSONL dataset, will use the value from the dataset if present.",
     )
     parser.add_argument(


### PR DESCRIPTION
test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only change to benchmark argument validation and help; no auth or serving logic.
> 
> **Overview**
> Extends the Locust load test CLI so **`--reasoning-effort`** accepts **`none`** in addition to `low`, `medium`, and `high`.
> 
> When set, that value is passed through on chat/completion requests as **`reasoning_effort`** (same as the other levels), so benchmarks can explicitly turn off thinking/reasoning on backends that support it. Help text documents using **`none`** for that purpose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71e2c1a72923ba00a3af6df53534d7328a1d88ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->