### PR TITLE
feat(load_test): add optional per-user x-session-affinity

### DIFF
--- a/llm_bench/README.md
+++ b/llm_bench/README.md
@@ -115,16 +115,14 @@ Use `--per-user-session-affinity` to assign each Locust user a stable, distinct
 
 ```bash
 locust -u 8 -r 8 --per-user-session-affinity \
-  --session-affinity-prefix shape-gha-1712345678 \
   -H https://api.fireworks.ai/inference \
   --api-key $FIREWORKS_API_KEY -m accounts/<account>/deployments/<deployment_id> \
   -p 1024 -o 128 -t 2min --headless
 ```
 
-Session ids look like `shape-gha-1712345678-user-0`, `shape-gha-1712345678-user-1`, ...
-so concurrent users in one run are distinct and different workflow runs do not reuse
-the same ids. You can pass the prefix explicitly or set `LOAD_TEST_RUN_ID` /
-`RUN_ID` / `GITHUB_RUN_ID` in the environment (for example the GHA `run_id` input).
+Session ids look like `user-0_a1b2c3d4e5f6`, `user-1_a1b2c3d4e5f6`, ... where the suffix is a
+random uuid generated once per load-test run (or an explicit `--session-affinity-prefix` /
+`LOAD_TEST_RUN_ID` when you want a workflow run id instead).
 
 With 8 users this creates 8 sticky sessions. The flag overrides any `x-session-affinity`
 passed via `--header`.

--- a/llm_bench/README.md
+++ b/llm_bench/README.md
@@ -103,6 +103,25 @@ Non-chat dataset (--no-chat option):
 {"prompt": "Five six seven eight"}
 ```
 
+### Session affinity
+
+Deployments with session-affinity routing (Envoy prompt-cache stickiness) need distinct
+`x-session-affinity` values to spread concurrent users across replicas. By default the
+load test does not set this header, so serverless traffic may collapse to a single
+account-level session.
+
+Use `--per-user-session-affinity` to assign each Locust user a stable, distinct
+`x-session-affinity` header for the duration of the test:
+
+```bash
+locust -u 8 -r 8 --per-user-session-affinity -H https://api.fireworks.ai/inference \
+  --api-key $FIREWORKS_API_KEY -m accounts/<account>/deployments/<deployment_id> \
+  -p 1024 -o 128 -t 2min --headless
+```
+
+With 8 users this creates 8 sticky sessions. The flag overrides any `x-session-affinity`
+passed via `--header`.
+
 
 ## Examples
 

--- a/llm_bench/README.md
+++ b/llm_bench/README.md
@@ -110,9 +110,8 @@ Deployments with session-affinity routing (Envoy prompt-cache stickiness) need d
 load test does not set this header, so serverless traffic may collapse to a single
 account-level session.
 
-Use `--per-user-session-affinity` (on by default) to assign each Locust user a stable,
-distinct `x-session-affinity` header for the duration of the test. Pass
-`--no-per-user-session-affinity` to disable.
+Use `--per-user-session-affinity` to assign each Locust user a stable, distinct
+`x-session-affinity` header for the duration of the test (off by default).
 
 ```bash
 locust -u 8 -r 8 -H https://api.fireworks.ai/inference \

--- a/llm_bench/README.md
+++ b/llm_bench/README.md
@@ -120,9 +120,8 @@ locust -u 8 -r 8 --per-user-session-affinity \
   -p 1024 -o 128 -t 2min --headless
 ```
 
-Session ids look like `user-0_a1b2c3d4e5f6`, `user-1_a1b2c3d4e5f6`, ... where the suffix is a
-random uuid generated once per load-test run (or an explicit `--session-affinity-prefix` /
-`LOAD_TEST_RUN_ID` when you want a workflow run id instead).
+Session ids are random uuids (e.g. `a1b2c3d4e5f6478990abcdef1234567890`), generated once
+per Locust user in `on_start` and reused for every request from that user.
 
 With 8 users this creates 8 sticky sessions. The flag overrides any `x-session-affinity`
 passed via `--header`.

--- a/llm_bench/README.md
+++ b/llm_bench/README.md
@@ -110,11 +110,12 @@ Deployments with session-affinity routing (Envoy prompt-cache stickiness) need d
 load test does not set this header, so serverless traffic may collapse to a single
 account-level session.
 
-Use `--per-user-session-affinity` to assign each Locust user a stable, distinct
-`x-session-affinity` header for the duration of the test:
+Use `--per-user-session-affinity` (on by default) to assign each Locust user a stable,
+distinct `x-session-affinity` header for the duration of the test. Pass
+`--no-per-user-session-affinity` to disable.
 
 ```bash
-locust -u 8 -r 8 --per-user-session-affinity \
+locust -u 8 -r 8 -H https://api.fireworks.ai/inference \
   -H https://api.fireworks.ai/inference \
   --api-key $FIREWORKS_API_KEY -m accounts/<account>/deployments/<deployment_id> \
   -p 1024 -o 128 -t 2min --headless

--- a/llm_bench/README.md
+++ b/llm_bench/README.md
@@ -114,10 +114,17 @@ Use `--per-user-session-affinity` to assign each Locust user a stable, distinct
 `x-session-affinity` header for the duration of the test:
 
 ```bash
-locust -u 8 -r 8 --per-user-session-affinity -H https://api.fireworks.ai/inference \
+locust -u 8 -r 8 --per-user-session-affinity \
+  --session-affinity-prefix shape-gha-1712345678 \
+  -H https://api.fireworks.ai/inference \
   --api-key $FIREWORKS_API_KEY -m accounts/<account>/deployments/<deployment_id> \
   -p 1024 -o 128 -t 2min --headless
 ```
+
+Session ids look like `shape-gha-1712345678-user-0`, `shape-gha-1712345678-user-1`, ...
+so concurrent users in one run are distinct and different workflow runs do not reuse
+the same ids. You can pass the prefix explicitly or set `LOAD_TEST_RUN_ID` /
+`RUN_ID` / `GITHUB_RUN_ID` in the environment (for example the GHA `run_id` input).
 
 With 8 users this creates 8 sticky sessions. The flag overrides any `x-session-affinity`
 passed via `--header`.

--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -33,41 +33,10 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-_PER_USER_SESSION_LOCK = threading.Lock()
-_PER_USER_SESSION_COUNTER = itertools.count()
-_RUN_SESSION_ID_LOCK = threading.Lock()
-_RUN_SESSION_ID: Optional[str] = None
-_SESSION_AFFINITY_RUN_ID_ENV_VARS = (
-    "LOAD_TEST_RUN_ID",
-    "RUN_ID",
-    "GITHUB_RUN_ID",
-)
 
-
-def _sanitize_run_session_id(value: str) -> str:
-    sanitized = re.sub(r"[^a-zA-Z0-9._-]+", "-", value.strip()).strip("-")
-    return sanitized[:32] if sanitized else uuid.uuid4().hex[:12]
-
-
-def _resolve_run_session_id(explicit: Optional[str]) -> str:
-    """Return the run-scoped id shared by all users in this load test."""
-    global _RUN_SESSION_ID
-    if explicit:
-        return _sanitize_run_session_id(explicit)
-    for env_var in _SESSION_AFFINITY_RUN_ID_ENV_VARS:
-        if value := os.environ.get(env_var, "").strip():
-            return _sanitize_run_session_id(value)
-    with _RUN_SESSION_ID_LOCK:
-        if _RUN_SESSION_ID is None:
-            _RUN_SESSION_ID = uuid.uuid4().hex[:12]
-        return _RUN_SESSION_ID
-
-
-def _per_user_session_affinity_value(*, run_id: str) -> str:
-    """Return a stable session id like user-0_<run_id> for this Locust user."""
-    with _PER_USER_SESSION_LOCK:
-        user_index = next(_PER_USER_SESSION_COUNTER)
-    return f"user-{user_index}_{run_id}"
+def _new_per_user_session_affinity_value() -> str:
+    """Return a random session id for one Locust user, reused for all its requests."""
+    return uuid.uuid4().hex
 
 
 try:
@@ -1346,12 +1315,9 @@ class LLMUser(HttpUser):
                 key, val = header.split(":", 1)
                 self.client.headers[key] = val
         if self.environment.parsed_options.per_user_session_affinity:
-            run_id = _resolve_run_session_id(
-                self.environment.parsed_options.session_affinity_prefix
-            )
-            session_id = _per_user_session_affinity_value(run_id=run_id)
-            self.client.headers["x-session-affinity"] = session_id
-            logger.info("Assigned per-user session affinity: %s", session_id)
+            self.session_affinity_id = _new_per_user_session_affinity_value()
+            self.client.headers["x-session-affinity"] = self.session_affinity_id
+            logger.info("Assigned per-user session affinity: %s", self.session_affinity_id)
         self._guess_provider()
         logger.info(f" Provider {self.provider} using model {self.model} ".center(80, "*"))
         self.provider_formatter = PROVIDER_CLASS_MAP[self.provider](self.model, self.environment.parsed_options)
@@ -2081,17 +2047,9 @@ def init_parser(parser):
         "--per-user-session-affinity",
         action=argparse.BooleanOptionalAction,
         default=False,
-        help="Assign each Locust user a distinct x-session-affinity header so concurrent "
-        "users spread across session-affinity routes (e.g. 8 users -> 8 sticky sessions). "
+        help="Assign each Locust user a distinct x-session-affinity header (a random uuid "
+        "generated once per user) so concurrent users spread across session-affinity routes. "
         "Overrides any x-session-affinity passed via --header.",
-    )
-    parser.add_argument(
-        "--session-affinity-prefix",
-        type=str,
-        default=None,
-        help="Optional run id suffix for per-user x-session-affinity ids. "
-        "Each user gets user-N_<run_id>. When unset, uses LOAD_TEST_RUN_ID, RUN_ID, "
-        "or GITHUB_RUN_ID from the environment, otherwise a random uuid per run.",
     )
     parser.add_argument(
         "-n",

--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -11,6 +11,7 @@ import random
 import sys
 import threading
 import traceback
+import uuid
 from typing import Any, Optional
 from locust import HttpUser, task, events, constant_pacing
 import copy
@@ -34,45 +35,39 @@ logger = logging.getLogger(__name__)
 
 _PER_USER_SESSION_LOCK = threading.Lock()
 _PER_USER_SESSION_COUNTER = itertools.count()
-_SESSION_AFFINITY_PREFIX_ENV_VARS = (
+_RUN_SESSION_ID_LOCK = threading.Lock()
+_RUN_SESSION_ID: Optional[str] = None
+_SESSION_AFFINITY_RUN_ID_ENV_VARS = (
     "LOAD_TEST_RUN_ID",
     "RUN_ID",
     "GITHUB_RUN_ID",
 )
 
 
-def _sanitize_session_prefix(value: str) -> str:
+def _sanitize_run_session_id(value: str) -> str:
     sanitized = re.sub(r"[^a-zA-Z0-9._-]+", "-", value.strip()).strip("-")
-    if not sanitized:
-        return f"loadtest-{os.getpid()}"
-    return sanitized[:96]
+    return sanitized[:32] if sanitized else uuid.uuid4().hex[:12]
 
 
-def _resolve_session_affinity_prefix(cli_prefix: Optional[str]) -> str:
-    if cli_prefix:
-        return _sanitize_session_prefix(cli_prefix)
-    for env_var in _SESSION_AFFINITY_PREFIX_ENV_VARS:
+def _resolve_run_session_id(explicit: Optional[str]) -> str:
+    """Return the run-scoped id shared by all users in this load test."""
+    global _RUN_SESSION_ID
+    if explicit:
+        return _sanitize_run_session_id(explicit)
+    for env_var in _SESSION_AFFINITY_RUN_ID_ENV_VARS:
         if value := os.environ.get(env_var, "").strip():
-            return _sanitize_session_prefix(value)
-    return _sanitize_session_prefix(f"loadtest-{os.getpid()}")
+            return _sanitize_run_session_id(value)
+    with _RUN_SESSION_ID_LOCK:
+        if _RUN_SESSION_ID is None:
+            _RUN_SESSION_ID = uuid.uuid4().hex[:12]
+        return _RUN_SESSION_ID
 
 
-def _session_affinity_worker_scope() -> Optional[str]:
-    for env_var in ("LOCUST_WORKER_INDEX", "LOAD_TEST_LOCUST_PROCESS_INDEX"):
-        if value := os.environ.get(env_var, "").strip():
-            return value
-    return None
-
-
-def _per_user_session_affinity_value(*, prefix: str) -> str:
-    """Return a stable session id unique to this Locust user within the run."""
+def _per_user_session_affinity_value(*, run_id: str) -> str:
+    """Return a stable session id like user-0_<run_id> for this Locust user."""
     with _PER_USER_SESSION_LOCK:
         user_index = next(_PER_USER_SESSION_COUNTER)
-    base = _sanitize_session_prefix(prefix)
-    worker_scope = _session_affinity_worker_scope()
-    if worker_scope is not None:
-        return f"{base}-proc{worker_scope}-user-{user_index}"
-    return f"{base}-user-{user_index}"
+    return f"user-{user_index}_{run_id}"
 
 
 try:
@@ -1351,10 +1346,10 @@ class LLMUser(HttpUser):
                 key, val = header.split(":", 1)
                 self.client.headers[key] = val
         if self.environment.parsed_options.per_user_session_affinity:
-            prefix = _resolve_session_affinity_prefix(
+            run_id = _resolve_run_session_id(
                 self.environment.parsed_options.session_affinity_prefix
             )
-            session_id = _per_user_session_affinity_value(prefix=prefix)
+            session_id = _per_user_session_affinity_value(run_id=run_id)
             self.client.headers["x-session-affinity"] = session_id
             logger.info("Assigned per-user session affinity: %s", session_id)
         self._guess_provider()
@@ -2094,9 +2089,9 @@ def init_parser(parser):
         "--session-affinity-prefix",
         type=str,
         default=None,
-        help="Prefix for per-user x-session-affinity ids (e.g. a GHA run_id). "
-        "Each user gets {prefix}-user-N. When unset, uses LOAD_TEST_RUN_ID, RUN_ID, "
-        "or GITHUB_RUN_ID from the environment, then loadtest-<pid>.",
+        help="Optional run id suffix for per-user x-session-affinity ids. "
+        "Each user gets user-N_<run_id>. When unset, uses LOAD_TEST_RUN_ID, RUN_ID, "
+        "or GITHUB_RUN_ID from the environment, otherwise a random uuid per run.",
     )
     parser.add_argument(
         "-n",

--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -2046,10 +2046,10 @@ def init_parser(parser):
     parser.add_argument(
         "--per-user-session-affinity",
         action=argparse.BooleanOptionalAction,
-        default=False,
+        default=True,
         help="Assign each Locust user a distinct x-session-affinity header (a random uuid "
         "generated once per user) so concurrent users spread across session-affinity routes. "
-        "Overrides any x-session-affinity passed via --header.",
+        "Overrides any x-session-affinity passed via --header. Default: enabled.",
     )
     parser.add_argument(
         "-n",

--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -2046,10 +2046,10 @@ def init_parser(parser):
     parser.add_argument(
         "--per-user-session-affinity",
         action=argparse.BooleanOptionalAction,
-        default=True,
+        default=False,
         help="Assign each Locust user a distinct x-session-affinity header (a random uuid "
         "generated once per user) so concurrent users spread across session-affinity routes. "
-        "Overrides any x-session-affinity passed via --header. Default: enabled.",
+        "Overrides any x-session-affinity passed via --header. Default: disabled.",
     )
     parser.add_argument(
         "-n",

--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -34,19 +34,51 @@ logger = logging.getLogger(__name__)
 
 _PER_USER_SESSION_LOCK = threading.Lock()
 _PER_USER_SESSION_COUNTER = itertools.count()
+_SESSION_AFFINITY_PREFIX_ENV_VARS = (
+    "LOAD_TEST_RUN_ID",
+    "RUN_ID",
+    "GITHUB_RUN_ID",
+)
+
+
+def _sanitize_session_prefix(value: str) -> str:
+    sanitized = re.sub(r"[^a-zA-Z0-9._-]+", "-", value.strip()).strip("-")
+    if not sanitized:
+        return f"loadtest-{os.getpid()}"
+    return sanitized[:96]
+
+
+def _resolve_session_affinity_prefix(cli_prefix: Optional[str]) -> str:
+    if cli_prefix:
+        return _sanitize_session_prefix(cli_prefix)
+    for env_var in _SESSION_AFFINITY_PREFIX_ENV_VARS:
+        if value := os.environ.get(env_var, "").strip():
+            return _sanitize_session_prefix(value)
+    return _sanitize_session_prefix(f"loadtest-{os.getpid()}")
+
+
+def _session_affinity_worker_scope() -> Optional[str]:
+    for env_var in ("LOCUST_WORKER_INDEX", "LOAD_TEST_LOCUST_PROCESS_INDEX"):
+        if value := os.environ.get(env_var, "").strip():
+            return value
+    return None
+
+
+def _per_user_session_affinity_value(*, prefix: str) -> str:
+    """Return a stable session id unique to this Locust user within the run."""
+    with _PER_USER_SESSION_LOCK:
+        user_index = next(_PER_USER_SESSION_COUNTER)
+    base = _sanitize_session_prefix(prefix)
+    worker_scope = _session_affinity_worker_scope()
+    if worker_scope is not None:
+        return f"{base}-proc{worker_scope}-user-{user_index}"
+    return f"{base}-user-{user_index}"
+
 
 try:
     import locust_plugins
 except ImportError:
     logger.warning("locust-plugins is not installed, Grafana won't work")
-
-
-def _per_user_session_affinity_value() -> str:
-    """Return a stable session id unique to this Locust user within the process."""
-    with _PER_USER_SESSION_LOCK:
-        user_index = next(_PER_USER_SESSION_COUNTER)
-    # Include pid so multi-process runs (e.g. locust --processes) do not reuse ids.
-    return f"loadtest-{os.getpid()}-user-{user_index}"
 
 
 def _install_transformers_tokenizer_compat_shim():
@@ -1319,7 +1351,10 @@ class LLMUser(HttpUser):
                 key, val = header.split(":", 1)
                 self.client.headers[key] = val
         if self.environment.parsed_options.per_user_session_affinity:
-            session_id = _per_user_session_affinity_value()
+            prefix = _resolve_session_affinity_prefix(
+                self.environment.parsed_options.session_affinity_prefix
+            )
+            session_id = _per_user_session_affinity_value(prefix=prefix)
             self.client.headers["x-session-affinity"] = session_id
             logger.info("Assigned per-user session affinity: %s", session_id)
         self._guess_provider()
@@ -2054,6 +2089,14 @@ def init_parser(parser):
         help="Assign each Locust user a distinct x-session-affinity header so concurrent "
         "users spread across session-affinity routes (e.g. 8 users -> 8 sticky sessions). "
         "Overrides any x-session-affinity passed via --header.",
+    )
+    parser.add_argument(
+        "--session-affinity-prefix",
+        type=str,
+        default=None,
+        help="Prefix for per-user x-session-affinity ids (e.g. a GHA run_id). "
+        "Each user gets {prefix}-user-N. When unset, uses LOAD_TEST_RUN_ID, RUN_ID, "
+        "or GITHUB_RUN_ID from the environment, then loadtest-<pid>.",
     )
     parser.add_argument(
         "-n",

--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -32,10 +32,21 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+_PER_USER_SESSION_LOCK = threading.Lock()
+_PER_USER_SESSION_COUNTER = itertools.count()
+
 try:
     import locust_plugins
 except ImportError:
     logger.warning("locust-plugins is not installed, Grafana won't work")
+
+
+def _per_user_session_affinity_value() -> str:
+    """Return a stable session id unique to this Locust user within the process."""
+    with _PER_USER_SESSION_LOCK:
+        user_index = next(_PER_USER_SESSION_COUNTER)
+    # Include pid so multi-process runs (e.g. locust --processes) do not reuse ids.
+    return f"loadtest-{os.getpid()}-user-{user_index}"
 
 
 def _install_transformers_tokenizer_compat_shim():
@@ -1307,6 +1318,10 @@ class LLMUser(HttpUser):
             for header in self.environment.parsed_options.header:
                 key, val = header.split(":", 1)
                 self.client.headers[key] = val
+        if self.environment.parsed_options.per_user_session_affinity:
+            session_id = _per_user_session_affinity_value()
+            self.client.headers["x-session-affinity"] = session_id
+            logger.info("Assigned per-user session affinity: %s", session_id)
         self._guess_provider()
         logger.info(f" Provider {self.provider} using model {self.model} ".center(80, "*"))
         self.provider_formatter = PROVIDER_CLASS_MAP[self.provider](self.model, self.environment.parsed_options)
@@ -2031,6 +2046,14 @@ def init_parser(parser):
         action="append",
         default=[],
         help="Arbitrary headers to add to the inference request. Can be used multiple times. For example, --header header1:value1 --header header2:value2",
+    )
+    parser.add_argument(
+        "--per-user-session-affinity",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Assign each Locust user a distinct x-session-affinity header so concurrent "
+        "users spread across session-affinity routes (e.g. 8 users -> 8 sticky sessions). "
+        "Overrides any x-session-affinity passed via --header.",
     )
     parser.add_argument(
         "-n",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Benchmark-only client header behavior in llm_bench; no production inference or auth paths change.
> 
> **Overview**
> Adds **`--per-user-session-affinity`** (off by default) so each Locust virtual user gets a stable random **`x-session-affinity`** value for all of its requests, which helps load tests hit multiple session-affinity / prompt-cache routes instead of collapsing onto one sticky session.
> 
> When enabled, the id is created in **`on_start`** via **`uuid.uuid4().hex`** and applied after **`--header`** processing, so it **overrides** any **`x-session-affinity`** set through **`--header`**. The README documents when to use this for Envoy stickiness and concurrent-user benchmarks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d45ce93c54376247c3b9eaf03e5dd85f2cf32bd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->