### PR TITLE
feat(llm-bench): exercise exact context boundaries

### DIFF
--- a/llm_bench/context_utils.py
+++ b/llm_bench/context_utils.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping
+from typing import Any
+
+import transformers
+from huggingface_hub import hf_hub_download
+
+MAX_SANE_CONTEXT_LENGTH = 1 << 24
+
+# Fireworks `/v1/completions` copies a non-empty list[int] prompt directly into
+# TokenizationOutput; it does not add BOS, EOS, or chat-template tokens. The
+# benchmark applies the chat template before sending those IDs. RequestAdmitter
+# then reserves one token for speculative lookahead:
+#   max_gen_tokens = model_max_seq_len - prompt_tokens - 1
+# and rejects when max_gen_tokens <= 0, including max_tokens=0 requests.
+# Keep this named for that server contract rather than treating -1/-2 as
+# unexplained safety margins.
+FIREWORKS_SPECULATIVE_LOOKAHEAD_TOKENS = 1
+
+_CONTEXT_LENGTH_FIELDS = (
+    "max_position_embeddings",
+    "model_max_length",
+    "max_sequence_length",
+    "seq_length",
+    "n_positions",
+)
+_NESTED_CONFIG_FIELDS = (
+    "text_config",
+    "language_config",
+    "llm_config",
+    "model_config",
+)
+
+
+def _config_value(config: Any, name: str) -> Any:
+    if isinstance(config, Mapping):
+        return config.get(name)
+    return getattr(config, name, None)
+
+
+def _config_candidates(config: Any) -> list[Any]:
+    candidates: list[Any] = []
+    get_text_config = getattr(config, "get_text_config", None)
+    if callable(get_text_config):
+        try:
+            candidates.append(get_text_config())
+        except Exception:
+            pass
+    candidates.append(config)
+
+    result: list[Any] = []
+    seen: set[int] = set()
+    while candidates:
+        candidate = candidates.pop(0)
+        if candidate is None or id(candidate) in seen:
+            continue
+        seen.add(id(candidate))
+        result.append(candidate)
+        for field in _NESTED_CONFIG_FIELDS:
+            nested = _config_value(candidate, field)
+            if nested is not None:
+                candidates.append(nested)
+    return result
+
+
+def _context_length_from_config(config: Any) -> tuple[int | None, list[str]]:
+    rejected: list[str] = []
+    for candidate in _config_candidates(config):
+        for field in _CONTEXT_LENGTH_FIELDS:
+            value = _config_value(candidate, field)
+            if value is None:
+                continue
+            if type(value) is int and 0 < value <= MAX_SANE_CONTEXT_LENGTH:
+                return value, rejected
+            rejected.append(f"{field}={value!r}")
+    return None, rejected
+
+
+def tokenizer_asset_path(tokenizer_path: str, filename: str) -> str:
+    if os.path.isdir(tokenizer_path):
+        path = os.path.join(tokenizer_path, filename)
+        if not os.path.isfile(path):
+            raise FileNotFoundError(f"Missing {filename} in local tokenizer directory {tokenizer_path}")
+        return path
+    return hf_hub_download(repo_id=tokenizer_path, filename=filename)
+
+
+def read_config_json(tokenizer_path: str) -> dict[str, Any]:
+    with open(tokenizer_asset_path(tokenizer_path, "config.json")) as config_file:
+        value = json.load(config_file)
+    if not isinstance(value, dict):
+        raise ValueError("config.json must contain a JSON object")
+    return value
+
+
+def resolve_max_seq_len(tokenizer_path: str) -> int:
+    """Resolve a finite model context length from local or Hugging Face config."""
+    errors: list[str] = []
+    rejected: list[str] = []
+
+    try:
+        config = transformers.AutoConfig.from_pretrained(tokenizer_path, trust_remote_code=True)
+    except Exception as error:
+        errors.append(f"AutoConfig: {error}")
+    else:
+        value, invalid = _context_length_from_config(config)
+        rejected.extend(invalid)
+        if value is not None:
+            return value
+
+    try:
+        raw_config = read_config_json(tokenizer_path)
+    except Exception as error:
+        errors.append(f"config.json: {error}")
+    else:
+        value, invalid = _context_length_from_config(raw_config)
+        rejected.extend(invalid)
+        if value is not None:
+            return value
+
+    details = errors + ([f"rejected values: {', '.join(dict.fromkeys(rejected))}"] if rejected else [])
+    suffix = f" ({'; '.join(details)})" if details else ""
+    raise ValueError(
+        "Could not infer a finite max sequence length from config; " f"pass --max-seq-len explicitly.{suffix}"
+    )
+
+
+def generate_geometric_lengths(min_seq_len: int, max_seq_len: int, factor: int) -> list[int]:
+    """Return geometric points plus the exact maximum, without duplicates."""
+    if min_seq_len < 1:
+        raise ValueError("min_seq_len must be positive")
+    if max_seq_len < 1:
+        raise ValueError("max_seq_len must be positive")
+    if min_seq_len > max_seq_len:
+        raise ValueError("min_seq_len must not exceed max_seq_len")
+    if factor <= 1:
+        raise ValueError("factor must be greater than one")
+
+    lengths: list[int] = []
+    seq_len = min_seq_len
+    while seq_len <= max_seq_len:
+        lengths.append(seq_len)
+        seq_len *= factor
+    if max_seq_len not in lengths:
+        lengths.append(max_seq_len)
+    return lengths
+
+
+def generation_sequence_limit(model_max_seq_len: int) -> int:
+    """Maximum prompt-plus-requested-output length admitted by completions."""
+    if model_max_seq_len <= FIREWORKS_SPECULATIVE_LOOKAHEAD_TOKENS:
+        raise ValueError("model max sequence length is too small for generation")
+    return model_max_seq_len - FIREWORKS_SPECULATIVE_LOOKAHEAD_TOKENS
+
+
+def prefill_prompt_limit(model_max_seq_len: int, max_tokens: int = 0) -> int:
+    """Maximum prompt length admitted for a prefill benchmark request."""
+    if max_tokens < 0:
+        raise ValueError("max_tokens must be non-negative")
+    required_generation_capacity = max(1, max_tokens)
+    prompt_limit = model_max_seq_len - FIREWORKS_SPECULATIVE_LOOKAHEAD_TOKENS - required_generation_capacity
+    if prompt_limit < 1:
+        raise ValueError("model max sequence length is too small for prefill")
+    return prompt_limit

--- a/llm_bench/gen_load_test.py
+++ b/llm_bench/gen_load_test.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
-import json
 import logging
 import os
 import random
@@ -30,8 +29,15 @@ logger = logging.getLogger(__name__)
 
 import requests
 import transformers
-from huggingface_hub import hf_hub_download
 from tabulate import tabulate
+
+from context_utils import (
+    generate_geometric_lengths,
+    generation_sequence_limit,
+    read_config_json,
+    resolve_max_seq_len,
+    tokenizer_asset_path,
+)
 
 FW_HEADER_PREFIX = "fireworks-"
 
@@ -84,31 +90,7 @@ def routing_headers_for_worker(cfg: Optional[RoutingConfig], worker_idx: int) ->
 
 _FAST_BATCH_SIZES = [1, 2, 3, 4, 5, 6, 7, 8]
 
-# NB: don't use power of 2 as we will use multiples of this to generate seq pairs
-# and in some cases it will batch max seq len of a model, which is the edge case we don't want to benchmark.
 _DEFAULT_MIN_SEQ_LEN = 1000
-_MAX_SEQ_LEN_CONFIG_FIELDS = (
-    "max_position_embeddings",
-    "model_max_length",
-    "max_sequence_length",
-    "seq_length",
-    "n_positions",
-)
-
-
-def _tokenizer_asset_path(tokenizer_path: str, filename: str) -> str:
-    if os.path.isdir(tokenizer_path):
-        path = os.path.join(tokenizer_path, filename)
-        if not os.path.isfile(path):
-            raise FileNotFoundError(f"Missing {filename} in local tokenizer directory {tokenizer_path}")
-        return path
-    return hf_hub_download(repo_id=tokenizer_path, filename=filename)
-
-
-def _read_config_json(tokenizer_path: str) -> dict[str, Any]:
-    config_path = _tokenizer_asset_path(tokenizer_path, "config.json")
-    with open(config_path) as f:
-        return json.load(f)
 
 
 def get_profile_batch_sizes(max_batch_size: int, min_batch_size: int = 1) -> list[int]:
@@ -136,38 +118,20 @@ def get_profile_batch_sizes(max_batch_size: int, min_batch_size: int = 1) -> lis
     return r
 
 
-def resolve_max_seq_len(tokenizer_path: str) -> int:
-    try:
-        config = transformers.AutoConfig.from_pretrained(tokenizer_path, trust_remote_code=True)
-        # For VLMs (e.g. Kimi K2.5, LLaMA Vision), max_position_embeddings lives
-        # under text_config rather than at the top level.
-        configs: tuple[Any, ...] = (config.get_text_config(),)
-    except ValueError:
-        config_json = _read_config_json(tokenizer_path)
-        configs = (config_json.get("text_config") or {}, config_json)
-
-    for config in configs:
-        for name in _MAX_SEQ_LEN_CONFIG_FIELDS:
-            v = config.get(name) if isinstance(config, Mapping) else getattr(config, name, None)
-            if isinstance(v, int) and v > 0:
-                return v
-    raise ValueError("Could not infer max sequence length from config; pass --max-seq-len explicitly.")
-
-
 def resolve_model_type(tokenizer_path: str) -> str:
     try:
         config = transformers.AutoConfig.from_pretrained(tokenizer_path, trust_remote_code=True)
         text_config = config.get_text_config()
         return getattr(text_config, "model_type", None) or getattr(config, "model_type", "")
-    except ValueError:
-        config_json = _read_config_json(tokenizer_path)
+    except Exception:
+        config_json = read_config_json(tokenizer_path)
         text_config = config_json.get("text_config") or {}
         return text_config.get("model_type") or config_json.get("model_type", "")
 
 
 @lru_cache(maxsize=None)
 def load_dsv4_encode_messages(tokenizer_path: str) -> Any:
-    path = _tokenizer_asset_path(tokenizer_path, "encoding/encoding_dsv4.py")
+    path = tokenizer_asset_path(tokenizer_path, "encoding/encoding_dsv4.py")
     spec = importlib.util.spec_from_file_location("hf_dsv4_encoding", path)
     if spec is None or spec.loader is None:
         raise RuntimeError(f"Could not load DSV4 encoding module from {path}")
@@ -177,12 +141,7 @@ def load_dsv4_encode_messages(tokenizer_path: str) -> Any:
 
 
 def generate_seq_lens(min_seq_len: int, max_seq_len: int) -> list[int]:
-    lens: list[int] = []
-    s = min_seq_len
-    while s <= max_seq_len:
-        lens.append(s)
-        s *= 2
-    return lens
+    return generate_geometric_lengths(min_seq_len, max_seq_len, factor=2)
 
 
 def _load_auto_tokenizer(tokenizer_path: str) -> transformers.PreTrainedTokenizer:
@@ -272,6 +231,24 @@ def _normalize_ids(obj: Any) -> list[int]:
     return [int(t) for t in obj]
 
 
+def split_chat_template_ids(
+    tokenizer: transformers.PreTrainedTokenizer,
+    tokenizer_path: str,
+    model_type: str,
+) -> tuple[list[int], list[int]]:
+    """Return the template token IDs before and after one user message."""
+    sentinel = "abcdefghij"
+    sentinel_ids = _normalize_ids(tokenizer.encode(sentinel, add_special_tokens=False))
+    if not sentinel_ids:
+        raise RuntimeError("Sentinel tokenized to an empty sequence")
+    templated = apply_chat_template_ids(tokenizer, tokenizer_path, sentinel, model_type)
+    width = len(sentinel_ids)
+    for index in range(len(templated) - width + 1):
+        if templated[index : index + width] == sentinel_ids:
+            return templated[:index], templated[index + width :]
+    raise RuntimeError(f"Could not locate sentinel IDs {sentinel_ids} in templated prompt")
+
+
 def build_chat_prompt_ids(
     tokenizer: transformers.PreTrainedTokenizer,
     tokenizer_path: str,
@@ -280,34 +257,32 @@ def build_chat_prompt_ids(
     chunk_texts: list[str],
     target_len: int,
 ) -> list[int]:
-    """Build chat-templated prompt ids of at most `target_len` tokens, chunk-aligned.
-
-    Bisects on chunk count to find the largest k such that the chat-templated
-    tokenization of `chunks[:k] + suffix` stays within `target_len`. This is
-    exact (no token-count estimation drift from chat template wrapping) at the
-    cost of O(log n) chat template tokenizations.
-    """
+    """Build an exact-length, client-templated prompt token sequence."""
     if not chunk_texts:
         raise ValueError("no chunks provided")
 
-    def length_for(k: int) -> int:
-        return len(apply_chat_template_ids(tokenizer, tokenizer_path, "".join(chunk_texts[:k]) + suffix_text, model_type))
+    prefix_ids, suffix_ids = split_chat_template_ids(tokenizer, tokenizer_path, model_type)
+    instruction_ids = _normalize_ids(tokenizer.encode(suffix_text, add_special_tokens=False))
+    content_len = target_len - len(prefix_ids) - len(suffix_ids)
+    body_len = content_len - len(instruction_ids)
+    if body_len < 0:
+        raise ValueError(f"target_len={target_len} is too small for the chat template and instruction")
 
-    if length_for(1) > target_len:
-        raise ValueError(f"target_len={target_len} too small to fit even one chunk")
+    body_ids: list[int] = []
+    chunk_index = 0
+    while len(body_ids) < body_len and chunk_index < 1_000_000:
+        chunk = chunk_texts[chunk_index % len(chunk_texts)]
+        body_ids.extend(_normalize_ids(tokenizer.encode(chunk, add_special_tokens=False)))
+        chunk_index += 1
+    if len(body_ids) < body_len:
+        raise RuntimeError(f"Could not build {body_len} dataset tokens")
 
-    n = len(chunk_texts)
-    if length_for(n) <= target_len:
-        return apply_chat_template_ids(tokenizer, tokenizer_path, "".join(chunk_texts) + suffix_text, model_type)
-
-    lo, hi = 1, n
-    while lo < hi:
-        mid = (lo + hi + 1) // 2
-        if length_for(mid) <= target_len:
-            lo = mid
-        else:
-            hi = mid - 1
-    return apply_chat_template_ids(tokenizer, tokenizer_path, "".join(chunk_texts[:lo]) + suffix_text, model_type)
+    # The completions endpoint accepts these IDs directly; it validates them but
+    # does not re-tokenize or add BOS/EOS tokens.
+    prompt_ids = prefix_ids + body_ids[:body_len] + instruction_ids + suffix_ids
+    if len(prompt_ids) != target_len:
+        raise RuntimeError(f"Built {len(prompt_ids)} prompt tokens, expected {target_len}")
+    return prompt_ids
 
 
 def get_header(headers: Mapping[str, str], short_key: str) -> Optional[float]:
@@ -370,6 +345,8 @@ def post_completion(
         "max_tokens": max_tokens,
         "n": n,
         "stream": False,
+        "ignore_eos": True,
+        "context_length_exceeded_behavior": "error",
     }
     if temperature is not None:
         payload["temperature"] = temperature
@@ -383,6 +360,23 @@ def post_completion(
     if extra_headers:
         headers.update(extra_headers)
     return session.post(url, headers=headers, json=payload, timeout=3600)
+
+
+def validate_completion_usage(
+    response_data: dict[str, Any],
+    expected_prompt_tokens: int,
+    expected_completion_tokens: int,
+) -> None:
+    """Verify the server used the exact pre-tokenized request boundary."""
+    usage = response_data.get("usage")
+    if not isinstance(usage, dict):
+        raise RuntimeError("Completion response is missing usage")
+    prompt_tokens = usage.get("prompt_tokens")
+    completion_tokens = usage.get("completion_tokens")
+    if prompt_tokens != expected_prompt_tokens:
+        raise RuntimeError(f"Server reported {prompt_tokens} prompt tokens; sent {expected_prompt_tokens} token IDs")
+    if completion_tokens != expected_completion_tokens:
+        raise RuntimeError(f"Server generated {completion_tokens} tokens; requested {expected_completion_tokens}")
 
 
 def parse_num_forward_passes(headers: Mapping[str, str], batch_size: int, completion_tokens: int) -> int:
@@ -454,7 +448,12 @@ def _run_pair_n_mode(
         )
 
     resp_json = r.json()
-    completion_tokens = resp_json.get("usage", {}).get("completion_tokens", max_tokens * batch_size)
+    completion_tokens = max_tokens * batch_size
+    validate_completion_usage(
+        resp_json,
+        expected_prompt_tokens=len(prompt_ids),
+        expected_completion_tokens=completion_tokens,
+    )
     num_fwd = parse_num_forward_passes(r.headers, batch_size, completion_tokens)
 
     fwp = get_int_header(r.headers, "prompt-tokens")
@@ -511,7 +510,10 @@ def _run_pair_separate_mode(
         headers = routing_headers_for_worker(routing, worker_offset + worker_idx)
         if headers and logger.isEnabledFor(logging.DEBUG):
             logger.debug(
-                "  worker=%d server=%s local=%s", worker_idx, headers.get(_SERVICE_INDEX_HEADER), headers.get(_LOCAL_INDEX_HEADER)
+                "  worker=%d server=%s local=%s",
+                worker_idx,
+                headers.get(_SERVICE_INDEX_HEADER),
+                headers.get(_LOCAL_INDEX_HEADER),
             )
         return post_completion(
             s,
@@ -547,8 +549,12 @@ def _run_pair_separate_mode(
             )
         gen_durs.append(gd)
         resp_json = r.json()
-        ct = resp_json.get("usage", {}).get("completion_tokens", max_tokens)
-        fwd_counts.append(parse_num_forward_passes(r.headers, batch_size=1, completion_tokens=ct))
+        validate_completion_usage(
+            resp_json,
+            expected_prompt_tokens=len(prompt_ids),
+            expected_completion_tokens=max_tokens,
+        )
+        fwd_counts.append(parse_num_forward_passes(r.headers, batch_size=1, completion_tokens=max_tokens))
 
     avg_gen_dur = sum(gen_durs) / len(gen_durs)
     avg_fwd = sum(fwd_counts) / len(fwd_counts)
@@ -688,15 +694,23 @@ def run_benchmark(
     seq_users: list[str] = []
     for seq_len, batch_size in pairs:
         if seq_len != prev_seq_len:
+            prompt_len = seq_len - max_tokens
+            if prompt_len < 1:
+                raise ValueError(f"seq_len={seq_len} must exceed max_tokens={max_tokens}")
             prompt_ids = build_chat_prompt_ids(
                 tokenizer,
                 tokenizer_path,
                 model_type,
                 suffix,
                 chunk_texts,
-                target_len=seq_len - max_tokens,
+                target_len=prompt_len,
             )
-            logger.info("Built prompt for seq_len=%d: %d tokens", seq_len, len(prompt_ids))
+            logger.info(
+                "Built exact boundary for seq_len=%d: prompt=%d + output=%d",
+                seq_len,
+                len(prompt_ids),
+                max_tokens,
+            )
             if separate_requests:
                 if prev_seq_len is None:
                     # HACK: backend OOMs without this pre-warmup on the largest
@@ -877,7 +891,8 @@ def main() -> None:
         "--max-seq-len",
         type=int,
         default=None,
-        help="Max sequence length (default: read from HF config). " "Used for auto-generating --seq-lens.",
+        help="Sequence-length cap used to generate geometric points plus the exact endpoint. "
+        "The default is the model config limit minus Fireworks generation headroom.",
     )
     parser.add_argument(
         "--min-seq-len",
@@ -901,7 +916,7 @@ def main() -> None:
         "--max-kv-cache-entries",
         type=int,
         default=None,
-        help="Cap batch size so (seq_len + max_tokens) * batch_size <= this value. "
+        help="Cap batch size so seq_len * batch_size <= this value. "
         "Applied to both auto-generated and explicit pairs.",
     )
     parser.add_argument(
@@ -984,22 +999,32 @@ def main() -> None:
         else:
             max_seq_len = args.max_seq_len
             try:
-                hf_max_seq_len = resolve_max_seq_len(args.tokenizer)
-                logger.info("Resolved max_seq_len=%d from HF config", hf_max_seq_len)
-            except ValueError:
-                hf_max_seq_len = None
+                model_max_seq_len = resolve_max_seq_len(args.tokenizer)
+                hf_sequence_limit = generation_sequence_limit(model_max_seq_len)
+                logger.info(
+                    "Resolved model max_seq_len=%d; completions generation limit=%d",
+                    model_max_seq_len,
+                    hf_sequence_limit,
+                )
+            except ValueError as error:
+                hf_sequence_limit = None
                 if max_seq_len is None:
-                    parser.error("Could not infer max sequence length from config; pass --max-seq-len explicitly.")
+                    parser.error(str(error))
             if max_seq_len is None:
-                max_seq_len = hf_max_seq_len
-            elif hf_max_seq_len is not None:
-                max_seq_len = min(max_seq_len, hf_max_seq_len)
+                max_seq_len = hf_sequence_limit
+            elif hf_sequence_limit is not None:
+                max_seq_len = min(max_seq_len, hf_sequence_limit)
             seq_lens = generate_seq_lens(args.min_seq_len, max_seq_len)
+            logger.info(
+                "Auto-generated sequence lengths including exact endpoint=%d: %s",
+                max_seq_len,
+                seq_lens,
+            )
         batch_sizes = get_profile_batch_sizes(args.max_batch_size, args.min_batch_size)
         pairs = [(s, b) for s in seq_lens for b in batch_sizes]
 
     if args.max_kv_cache_entries is not None:
-        pairs = [(s, b) for s, b in pairs if (s + args.max_tokens) * b <= args.max_kv_cache_entries]
+        pairs = [(s, b) for s, b in pairs if s * b <= args.max_kv_cache_entries]
 
     if len(pairs) == 0:
         raise RuntimeError("No seq:batch pairs")

--- a/llm_bench/prefill_load_test.py
+++ b/llm_bench/prefill_load_test.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
-import json
 import logging
 import os
 import random
@@ -32,9 +31,16 @@ logger = logging.getLogger(__name__)
 
 import requests
 import transformers
-from huggingface_hub import hf_hub_download
 
 from tabulate import tabulate
+
+from context_utils import (
+    generate_geometric_lengths,
+    prefill_prompt_limit,
+    read_config_json,
+    resolve_max_seq_len,
+    tokenizer_asset_path,
+)
 
 FW_HEADER_PREFIX = "fireworks-"
 STAGE_HEADER_KEYS = (
@@ -97,53 +103,12 @@ def routing_headers_for_worker(cfg: Optional[RoutingConfig], worker_idx: int) ->
     local = flat // cfg.num_servers
     return {_SERVICE_INDEX_HEADER: str(server), _LOCAL_INDEX_HEADER: str(local)}
 
-# NB: don't use power of 2 as we will use multiples of this to generate seq pairs
-# and in some cases it will batch max seq len of a model, which is the edge case we don't want to benchmark.
+
 _DEFAULT_MIN_SEQ_LEN = 500
-_MAX_SEQ_LEN_CONFIG_FIELDS = (
-    "max_position_embeddings",
-    "model_max_length",
-    "max_sequence_length",
-    "seq_length",
-    "n_positions",
-)
-
-
-def _tokenizer_asset_path(tokenizer_path: str, filename: str) -> str:
-    if os.path.isdir(tokenizer_path):
-        path = os.path.join(tokenizer_path, filename)
-        if not os.path.isfile(path):
-            raise FileNotFoundError(f"Missing {filename} in local tokenizer directory {tokenizer_path}")
-        return path
-    return hf_hub_download(repo_id=tokenizer_path, filename=filename)
-
-
-def _read_config_json(tokenizer_path: str) -> dict[str, Any]:
-    config_path = _tokenizer_asset_path(tokenizer_path, "config.json")
-    with open(config_path) as f:
-        return json.load(f)
 
 
 def _load_auto_tokenizer(tokenizer_path: str) -> transformers.PreTrainedTokenizer:
     return transformers.AutoTokenizer.from_pretrained(tokenizer_path, trust_remote_code=True)
-
-
-def resolve_max_seq_len(tokenizer_path: str) -> int:
-    try:
-        config = transformers.AutoConfig.from_pretrained(tokenizer_path, trust_remote_code=True)
-        # For VLMs (e.g. Kimi K2.5, LLaMA Vision), max_position_embeddings lives
-        # under text_config rather than at the top level.
-        configs: tuple[Any, ...] = (config.get_text_config(),)
-    except ValueError:
-        config_json = _read_config_json(tokenizer_path)
-        configs = (config_json.get("text_config") or {}, config_json)
-
-    for config in configs:
-        for name in _MAX_SEQ_LEN_CONFIG_FIELDS:
-            v = config.get(name) if isinstance(config, Mapping) else getattr(config, name, None)
-            if isinstance(v, int) and v > 0:
-                return v
-    raise ValueError("Could not infer max sequence length from config; pass --max-seq-len explicitly.")
 
 
 def resolve_model_type(tokenizer_path: str) -> str:
@@ -151,15 +116,15 @@ def resolve_model_type(tokenizer_path: str) -> str:
         config = transformers.AutoConfig.from_pretrained(tokenizer_path, trust_remote_code=True)
         text_config = config.get_text_config()
         return getattr(text_config, "model_type", None) or getattr(config, "model_type", "")
-    except ValueError:
-        config_json = _read_config_json(tokenizer_path)
+    except Exception:
+        config_json = read_config_json(tokenizer_path)
         text_config = config_json.get("text_config") or {}
         return text_config.get("model_type") or config_json.get("model_type", "")
 
 
 @lru_cache(maxsize=None)
 def load_dsv4_encode_messages(tokenizer_path: str) -> Any:
-    path = _tokenizer_asset_path(tokenizer_path, "encoding/encoding_dsv4.py")
+    path = tokenizer_asset_path(tokenizer_path, "encoding/encoding_dsv4.py")
     spec = importlib.util.spec_from_file_location("hf_dsv4_encoding", path)
     if spec is None or spec.loader is None:
         raise RuntimeError(f"Could not load DSV4 encoding module from {path}")
@@ -170,8 +135,7 @@ def load_dsv4_encode_messages(tokenizer_path: str) -> Any:
 
 def generate_pairs(max_seq_len: int, min_seq_len: int) -> list[tuple[int, int]]:
     pairs: list[tuple[int, int]] = []
-    s = min_seq_len
-    while s <= max_seq_len:
+    for s in generate_geometric_lengths(min_seq_len, max_seq_len, factor=4):
         step = s // 8
         cached_points = [step * multiplier for multiplier in [0, 1, 3, 5, 7]]
         if step >= 4000:
@@ -182,7 +146,6 @@ def generate_pairs(max_seq_len: int, min_seq_len: int) -> list[tuple[int, int]]:
         for c in sorted(set(cached_points)):
             if c <= s:
                 pairs.append((s, c))
-        s *= 4
     return pairs
 
 
@@ -454,6 +417,11 @@ def _send_and_parse_measurement(
     if r.status_code != 200:
         raise RuntimeError(f"Request failed HTTP {r.status_code}: {r.text[:500]}")
 
+    validate_completion_usage(
+        r.json(),
+        expected_prompt_tokens=sum(len(prompt) for prompt in prompt_token_ids),
+        expected_completion_tokens=max_tokens * len(prompt_token_ids),
+    )
     fwp = get_int_header(r.headers, "prompt-tokens")
     fwc = get_int_header(r.headers, "cached-prompt-tokens")
     server_processing = get_header(r.headers, "server-processing-time")
@@ -491,12 +459,12 @@ def _measure_pair_split_across_workers(
     total_workers = routing.total_workers
     # Stride-slice for even round-robin distribution. Uneven splits handled
     # naturally (e.g. 1985 / 4 -> [497, 496, 496, 496]).
-    chunks: list[list[list[int]]] = [
-        prompt_token_ids[i::total_workers] for i in range(total_workers)
-    ]
+    chunks: list[list[list[int]]] = [prompt_token_ids[i::total_workers] for i in range(total_workers)]
     active_workers = [i for i, c in enumerate(chunks) if c]
 
-    def _run_worker(worker_idx: int) -> tuple[int, float, float, Optional[int], Optional[int]]:
+    def _run_worker(
+        worker_idx: int,
+    ) -> tuple[int, float, float, Optional[int], Optional[int]]:
         # Distinct session per worker to avoid HTTP/2 multiplexing bias on a shared session.
         s = requests.Session()
         try:
@@ -560,6 +528,8 @@ def post_completion(
         "max_tokens": max_tokens,
         "stream": False,
         "temperature": 0.0,
+        "ignore_eos": True,
+        "context_length_exceeded_behavior": "error",
         "user": "0",  # NB: in case of DP w/ inline prefill we need to ensure generator stickiness
     }
     if prompt_cache_max_len is not None:
@@ -572,6 +542,23 @@ def post_completion(
     if extra_headers:
         headers.update(extra_headers)
     return session.post(url, headers=headers, json=payload, timeout=3600)
+
+
+def validate_completion_usage(
+    response_data: dict[str, Any],
+    expected_prompt_tokens: int,
+    expected_completion_tokens: int,
+) -> None:
+    """Verify the server used the exact pre-tokenized request boundary."""
+    usage = response_data.get("usage")
+    if not isinstance(usage, dict):
+        raise RuntimeError("Completion response is missing usage")
+    prompt_tokens = usage.get("prompt_tokens")
+    completion_tokens = usage.get("completion_tokens")
+    if prompt_tokens != expected_prompt_tokens:
+        raise RuntimeError(f"Server reported {prompt_tokens} prompt tokens; sent {expected_prompt_tokens} token IDs")
+    if completion_tokens != expected_completion_tokens:
+        raise RuntimeError(f"Server generated {completion_tokens} tokens; requested {expected_completion_tokens}")
 
 
 def run_benchmark(
@@ -617,7 +604,13 @@ def run_benchmark(
     def do_warmup(cached_tokens: int, extra_headers: Optional[dict[str, str]] = None) -> None:
         warmup_ids = build_warmup_ids(chat_prefix_ids, base_ids, cached_tokens)
         w = post_completion(
-            session, url, api_key, model, warmup_ids, max_tokens, extra_headers=extra_headers
+            session,
+            url,
+            api_key,
+            model,
+            warmup_ids,
+            max_tokens,
+            extra_headers=extra_headers,
         )
         if w.status_code != 200:
             raise RuntimeError(f"Warmup failed HTTP {w.status_code}: {w.text[:500]}")
@@ -744,8 +737,12 @@ def format_table(rows: list[PairBenchmarkResult]) -> str:
                 row.num_prompts,
                 row.duration,
                 row.client_duration,
-                row.mean_fireworks_prompt_tokens if row.mean_fireworks_prompt_tokens is not None else "",
-                row.mean_fireworks_cached_prompt_tokens if row.mean_fireworks_cached_prompt_tokens is not None else "",
+                (row.mean_fireworks_prompt_tokens if row.mean_fireworks_prompt_tokens is not None else ""),
+                (
+                    row.mean_fireworks_cached_prompt_tokens
+                    if row.mean_fireworks_cached_prompt_tokens is not None
+                    else ""
+                ),
             ]
         )
     return tabulate(
@@ -786,7 +783,7 @@ def format_csv(rows: list[PairBenchmarkResult]) -> str:
                     row.num_prompts,
                     f"{row.duration:.6f}",
                     f"{row.client_duration:.6f}",
-                    row.mean_fireworks_prompt_tokens if row.mean_fireworks_prompt_tokens is not None else "",
+                    (row.mean_fireworks_prompt_tokens if row.mean_fireworks_prompt_tokens is not None else ""),
                     (
                         row.mean_fireworks_cached_prompt_tokens
                         if row.mean_fireworks_cached_prompt_tokens is not None
@@ -831,7 +828,8 @@ def main() -> None:
         "--max-seq-len",
         type=int,
         default=None,
-        help="Max sequence length (default: read from HF config).",
+        help="Prompt-length cap used to generate geometric points plus the exact endpoint. "
+        "The default is the model config limit minus Fireworks prefill headroom.",
     )
     parser.add_argument(
         "--min-seq-len",
@@ -852,7 +850,12 @@ def main() -> None:
         default=131072,
         help="Minimum total prompt tokens to accumulate per batch (default 64K).",
     )
-    parser.add_argument("--max-tokens", type=int, default=0, help="max_tokens for completions (default 0).")
+    parser.add_argument(
+        "--max-tokens",
+        type=int,
+        default=0,
+        help="max_tokens for completions (default 0).",
+    )
     parser.add_argument(
         "--seed",
         type=int,
@@ -915,22 +918,32 @@ def main() -> None:
 
     max_seq_len = args.max_seq_len
     try:
-        hf_max_seq_len = resolve_max_seq_len(args.tokenizer)
-        logger.info("Resolved max_seq_len=%s from HF config", hf_max_seq_len)
-    except ValueError:
-        hf_max_seq_len = None
+        model_max_seq_len = resolve_max_seq_len(args.tokenizer)
+        hf_prompt_limit = prefill_prompt_limit(model_max_seq_len, max_tokens=args.max_tokens)
+        logger.info(
+            "Resolved model max_seq_len=%d; completions prefill prompt limit=%d",
+            model_max_seq_len,
+            hf_prompt_limit,
+        )
+    except ValueError as error:
+        hf_prompt_limit = None
         if max_seq_len is None:
-            parser.error("Could not infer max sequence length from config; pass --max-seq-len explicitly.")
+            parser.error(str(error))
     if max_seq_len is None:
-        max_seq_len = hf_max_seq_len
-    elif hf_max_seq_len is not None:
-        max_seq_len = min(max_seq_len, hf_max_seq_len)
+        max_seq_len = hf_prompt_limit
+    elif hf_prompt_limit is not None:
+        max_seq_len = min(max_seq_len, hf_prompt_limit)
 
     if args.seq_pairs is not None:
         pairs = parse_pairs_arg(args.seq_pairs)
     else:
         pairs = generate_pairs(max_seq_len, min_seq_len=args.min_seq_len)
-        logger.info("Auto-generated %d pairs: %s", len(pairs), pairs)
+        logger.info(
+            "Auto-generated %d pairs including exact prompt endpoint=%d: %s",
+            len(pairs),
+            max_seq_len,
+            pairs,
+        )
 
     rows = run_benchmark(
         tokenizer_path=args.tokenizer,

--- a/llm_bench/test_context_boundaries.py
+++ b/llm_bench/test_context_boundaries.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import context_utils
+import gen_load_test
+import prefill_load_test
+from context_utils import (
+    generate_geometric_lengths,
+    generation_sequence_limit,
+    prefill_prompt_limit,
+    resolve_max_seq_len,
+)
+
+
+@pytest.mark.parametrize("maximum", [131072, 420000, 1048576])
+@pytest.mark.parametrize("factor", [2, 4])
+def test_geometric_lengths_append_exact_maximum(maximum: int, factor: int) -> None:
+    lengths = generate_geometric_lengths(1000, maximum, factor=factor)
+
+    assert lengths[-1] == maximum
+    assert lengths.count(maximum) == 1
+    assert lengths[:-1] == [value for value in lengths[:-1] if value < maximum]
+
+
+@pytest.mark.parametrize("maximum", [131072, 420000, 1048576])
+def test_generation_lengths_include_exact_endpoint(maximum: int) -> None:
+    lengths = gen_load_test.generate_seq_lens(1000, maximum)
+
+    assert lengths[-1] == maximum
+    assert lengths.count(maximum) == 1
+
+
+def test_geometric_lengths_do_not_duplicate_geometric_maximum() -> None:
+    assert generate_geometric_lengths(1000, 128000, factor=2).count(128000) == 1
+    assert generate_geometric_lengths(500, 128000, factor=4).count(128000) == 1
+
+
+@pytest.mark.parametrize("maximum", [131072, 420000, 1048576])
+def test_prefill_pairs_include_exact_prompt_endpoint(maximum: int) -> None:
+    prompt_lengths = {prompt_tokens for prompt_tokens, _ in prefill_load_test.generate_pairs(maximum, 500)}
+
+    assert maximum in prompt_lengths
+
+
+@pytest.mark.parametrize("model_max", [131072, 420000, 1048576])
+def test_endpoint_limits_match_fireworks_admission_contract(model_max: int) -> None:
+    lookahead = context_utils.FIREWORKS_SPECULATIVE_LOOKAHEAD_TOKENS
+
+    generation_limit = generation_sequence_limit(model_max)
+    assert generation_limit + lookahead == model_max
+
+    zero_token_prefill_limit = prefill_prompt_limit(model_max)
+    assert zero_token_prefill_limit + lookahead + 1 == model_max
+
+    generation_prefill_limit = prefill_prompt_limit(model_max, max_tokens=100)
+    assert generation_prefill_limit + lookahead + 100 == model_max
+
+
+def test_resolver_falls_back_after_custom_config_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        context_utils.transformers.AutoConfig,
+        "from_pretrained",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("custom config failed")),
+    )
+    (tmp_path / "config.json").write_text(json.dumps({"language_config": {"max_position_embeddings": 420000}}))
+
+    assert resolve_max_seq_len(str(tmp_path)) == 420000
+
+
+def test_resolver_uses_sane_alternate_after_hf_sentinel(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        context_utils.transformers.AutoConfig,
+        "from_pretrained",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("unsupported")),
+    )
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "text_config": {
+                    "model_max_length": 1000000000000000019884624838656,
+                    "n_positions": 1048576,
+                }
+            }
+        )
+    )
+
+    assert resolve_max_seq_len(str(tmp_path)) == 1048576
+
+
+@pytest.mark.parametrize(
+    "config_text",
+    [
+        '{"model_max_length": 1000000000000000019884624838656}',
+        '{"max_position_embeddings": true}',
+        '{"max_position_embeddings": 0}',
+        '{"max_position_embeddings": 16777217}',
+        "{malformed",
+    ],
+)
+def test_resolver_normalizes_invalid_configs(
+    config_text: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        context_utils.transformers.AutoConfig,
+        "from_pretrained",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("load failed")),
+    )
+    (tmp_path / "config.json").write_text(config_text)
+
+    with pytest.raises(ValueError, match="Could not infer a finite max sequence length"):
+        resolve_max_seq_len(str(tmp_path))
+
+
+class _FakeTokenizer:
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        del add_special_tokens
+        return [ord(char) for char in text]
+
+    def apply_chat_template(
+        self,
+        messages: list[dict[str, str]],
+        *,
+        tokenize: bool,
+        add_generation_prompt: bool,
+    ) -> list[int]:
+        assert tokenize is True
+        assert add_generation_prompt is True
+        return [1] + self.encode(messages[0]["content"]) + [2]
+
+
+def test_generation_prompt_builder_hits_exact_token_target() -> None:
+    prompt = gen_load_test.build_chat_prompt_ids(
+        _FakeTokenizer(),
+        tokenizer_path="unused",
+        model_type="test",
+        suffix_text="XY",
+        chunk_texts=["abc"],
+        target_len=25,
+    )
+
+    assert len(prompt) == 25
+    assert prompt[:1] == [1]
+    assert prompt[-3:] == [ord("X"), ord("Y"), 2]
+
+
+class _RecordingSession:
+    def __init__(self) -> None:
+        self.payload: dict[str, Any] | None = None
+
+    def post(self, _url: str, **kwargs: Any) -> object:
+        self.payload = kwargs["json"]
+        return object()
+
+
+def test_generation_completion_sends_raw_ids_with_strict_context_behavior() -> None:
+    session = _RecordingSession()
+    prompt_ids = [1, 2, 3]
+
+    gen_load_test.post_completion(
+        session,
+        "https://example.test/v1/completions",
+        api_key=None,
+        model="model",
+        prompt=prompt_ids,
+        max_tokens=7,
+        n=1,
+    )
+
+    assert session.payload is not None
+    assert session.payload["prompt"] is prompt_ids
+    assert session.payload["ignore_eos"] is True
+    assert session.payload["context_length_exceeded_behavior"] == "error"
+
+
+def test_prefill_completion_sends_raw_ids_with_strict_context_behavior() -> None:
+    session = _RecordingSession()
+    prompt_ids = [[1, 2], [3, 4]]
+
+    prefill_load_test.post_completion(
+        session,
+        "https://example.test/v1/completions",
+        api_key=None,
+        model="model",
+        prompt=prompt_ids,
+        max_tokens=0,
+    )
+
+    assert session.payload is not None
+    assert session.payload["prompt"] is prompt_ids
+    assert session.payload["context_length_exceeded_behavior"] == "error"
+
+
+def test_usage_validation_rejects_server_added_prompt_tokens() -> None:
+    with pytest.raises(RuntimeError, match="sent 3 token IDs"):
+        gen_load_test.validate_completion_usage(
+            {"usage": {"prompt_tokens": 4, "completion_tokens": 7}},
+            expected_prompt_tokens=3,
+            expected_completion_tokens=7,
+        )


### PR DESCRIPTION
## Summary
- preserve generation and prefill geometric grids while appending each exact safe endpoint
- derive generation/prefill token budgets from Fireworks `/v1/completions` admission semantics and verify reported usage
- reject malformed or effectively infinite context metadata and cover boundary behavior directly

## Test plan
- [x] `PYTHONPATH=llm_bench /tmp/pr36116-venv/bin/python -m pytest -q` (27 passed)
- [x] Black check at line length 119
- [x] Python compile check for changed clients
- [x] Cross-repo GPU E2E 1 — H200 `gpt_oss-120b`: [fireworks run 30133937435](https://github.com/fw-ai/fireworks/actions/runs/30133937435) **success**
- [x] Cross-repo GPU E2E 2 — Kimi long-context: [fireworks run 30134885287](https://github.com/fw-ai/fireworks/actions/runs/30134885287) **success**

### E2E Evidence (this PR's client at `a3f0a732694`)

Both successful Fireworks workflow runs exercised this PR's exact-boundary client changes (`a3f0a732694`) via the companion [fireworks#36116](https://github.com/fw-ai/fireworks/pull/36116) pin.

#### E2E 1 — H200 `gpt_oss-120b` (exact-boundary + draft prefill)

- [Run 30133937435](https://github.com/fw-ai/fireworks/actions/runs/30133937435) — **success**
- Fireworks: `61595bd207e`, Benchmark: `a3f0a732694`
- Exactly 2 cells (`h200-fp4 / 1gpu-0draft`, `h200-fp4 / 1gpu-5draft`); both ran generation + prefill
- Resolved context `131072` → generation `131071` (`130971`+`100`), prefill `131070` (36/36 rows)
- KV slots: 0-draft `859712`, 5-draft `763968`; training succeeded with explicit 0-draft prefill fitting

#### E2E 2 — Kimi long-context single cell

- [Run 30134885287](https://github.com/fw-ai/fireworks/actions/runs/30134885287) — **success**
- Fireworks: `61595bd207e`, Benchmark: `a3f0a732694`
- One cell: B200 FP4 4-GPU 0-draft (`kimi_k25-1000b`)
- Model max `262144` → generation `262143` (batches 1–8), prefill `262142` (7/7 cache points)
- `kv_cache_slots=2438144`; training succeeded

## Integration
Companion dependency for fw-ai/fireworks#36116. Merge this PR first; the Fireworks workflow pins this commit and exposes an explicit `benchmark_ref` dispatch override for integration testing. If squash/rebase produces a different final SHA than `a3f0a732694`, update fireworks#36116's pin before merging that PR.

Made with [Cursor](https://cursor.com)
