### PR TITLE
fix(llm-bench): stop reading embeddings/rerank responses through iter_lines

### DIFF
--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -133,6 +133,26 @@ def empty_chat_template_token_ids(
     )
 
 
+_PROMPT_TOKENS_RE = re.compile(rb'"prompt_tokens"\s*:\s*(\d+)')
+
+
+def extract_prompt_tokens(body: bytes) -> Optional[int]:
+    """Read usage.prompt_tokens out of a response body without fully decoding it.
+
+    A batched embeddings response is almost entirely the float arrays under `data`.
+    Decoding those into Python objects just to read `usage` costs orders of magnitude
+    more than scanning for the field, and that cost lands on the load generator.
+    Falls back to a real parse if the scan misses.
+    """
+    match = _PROMPT_TOKENS_RE.search(body)
+    if match:
+        return int(match.group(1))
+    try:
+        return (orjson.loads(body).get("usage") or {}).get("prompt_tokens")
+    except orjson.JSONDecodeError:
+        return None
+
+
 def add_custom_metric(name, value, length_value=0):
     events.request.fire(
         request_type="METRIC",
@@ -1566,7 +1586,47 @@ class LLMUser(HttpUser):
                 return
             t_first_token = None
             t_first_visible_token = None
-            for chunk in response.iter_lines(delimiter=b"\n\n"):
+
+            # Rerank and embeddings are single-response JSON APIs. Draining them through
+            # iter_lines(delimiter=b"\n\n") makes the interpreter scan the whole body for a
+            # separator a JSON document never contains, so a multi-megabyte batched
+            # embeddings response gets buffered and rescanned in Python. Under gevent that
+            # scan is not cooperative, so it serializes across greenlets and caps client
+            # throughput well below what the endpoint can serve. Read the body once here
+            # and leave the chunk loop to the streaming paths.
+            if self.provider_formatter.parsed_options.rerank or self.provider_formatter.parsed_options.embeddings:
+                body = response.content
+                now = time.perf_counter()
+                t_first_token = now
+                # Recorded so a client-side ceiling is visible in the results rather than
+                # being mistaken for server latency.
+                add_custom_metric("response_bytes", len(body))
+                show_response = self.environment.parsed_options.show_response
+
+                if self.provider_formatter.parsed_options.rerank:
+                    out = self.provider_formatter.parse_output_json(orjson.loads(body))
+                    if out.prompt_tokens:
+                        prompt_tokens = out.prompt_tokens
+                    if show_response:
+                        combined_text = out.text
+                else:
+                    if show_response:
+                        resp_data = orjson.loads(body)
+                        server_prompt_tokens = (resp_data.get("usage") or {}).get("prompt_tokens")
+                        out = self.provider_formatter.parse_output_json(resp_data)
+                        combined_text = str(out.text)
+                    else:
+                        server_prompt_tokens = extract_prompt_tokens(body)
+                    if server_prompt_tokens:
+                        prompt_tokens = server_prompt_tokens
+                    add_custom_metric("latency_per_embedding", (now - t_start) / batch_size * 1000)
+
+                # Body is already consumed; fall through to the shared accounting below.
+                chunks = ()
+            else:
+                chunks = response.iter_lines(delimiter=b"\n\n")
+
+            for chunk in chunks:
                 if len(chunk) == 0:
                     continue  # come providers send empty lines between data chunks
                 if done:
@@ -1574,25 +1634,6 @@ class LLMUser(HttpUser):
                         logger.warning(f"Received more chunks after [DONE]: {chunk}")
                 try:
                     now = time.perf_counter()
-                    if self.provider_formatter.parsed_options.rerank:
-                        t_first_token = now
-                        out = self.provider_formatter.parse_output_json(orjson.loads(chunk))
-                        if out.prompt_tokens:
-                            prompt_tokens = out.prompt_tokens
-                        if self.environment.parsed_options.show_response:
-                            combined_text = out.text
-                        break
-                    if self.provider_formatter.parsed_options.embeddings:
-                        t_first_token = now
-                        resp_data = orjson.loads(chunk)
-                        usage = resp_data.get("usage", {})
-                        if usage.get("prompt_tokens"):
-                            prompt_tokens = usage["prompt_tokens"]
-                        if self.environment.parsed_options.show_response:
-                            out = self.provider_formatter.parse_output_json(resp_data)
-                            combined_text = str(out.text)
-                        add_custom_metric("latency_per_embedding", (now - t_start) / batch_size * 1000)
-                        break
                     if self.stream:
                         assert chunk.startswith(b"data:"), f"Unexpected chunk not starting with 'data': {chunk}"
                         chunk = chunk[len(b"data:") :]
@@ -2144,11 +2185,17 @@ def _(environment, **kw):
         return entry.avg_response_time if entry else ""
 
     if getattr(environment.parsed_options, "embeddings", False):
-        for metric_name in ["total_latency", "latency_per_embedding", "prompt_tokens"]:
+        for metric_name in [
+            "total_latency",
+            "latency_per_embedding",
+            "prompt_tokens",
+            "response_bytes",
+            "server_side_total_latency",
+        ]:
             entries[metric_name] = _avg(metric_name)
-        percentile_metrics = ["total_latency", "latency_per_embedding"]
+        percentile_metrics = ["total_latency", "latency_per_embedding", "server_side_total_latency"]
     elif getattr(environment.parsed_options, "rerank", False):
-        for metric_name in ["total_latency", "prompt_tokens"]:
+        for metric_name in ["total_latency", "prompt_tokens", "response_bytes", "server_side_total_latency"]:
             entries[metric_name] = _avg(metric_name)
         # Include rerank sweep params when set
         num_docs = getattr(environment.parsed_options, "num_documents", None)
@@ -2157,7 +2204,7 @@ def _(environment, **kw):
             entries["num_documents"] = num_docs
         if tokens_per_doc is not None:
             entries["tokens_per_document"] = tokens_per_doc
-        percentile_metrics = ["total_latency"]
+        percentile_metrics = ["total_latency", "server_side_total_latency"]
     else:
         for metric_name in [
             "time_to_first_token",

--- a/llm_bench/load_test.py
+++ b/llm_bench/load_test.py
@@ -1596,27 +1596,41 @@ class LLMUser(HttpUser):
             # and leave the chunk loop to the streaming paths.
             if self.provider_formatter.parsed_options.rerank or self.provider_formatter.parsed_options.embeddings:
                 body = response.content
-                now = time.perf_counter()
-                t_first_token = now
                 # Recorded so a client-side ceiling is visible in the results rather than
                 # being mistaken for server latency.
                 add_custom_metric("response_bytes", len(body))
                 show_response = self.environment.parsed_options.show_response
 
-                if self.provider_formatter.parsed_options.rerank:
-                    out = self.provider_formatter.parse_output_json(orjson.loads(body))
-                    if out.prompt_tokens:
-                        prompt_tokens = out.prompt_tokens
-                    if show_response:
-                        combined_text = out.text
-                else:
-                    if show_response:
+                # An empty or unparseable body is a failed request, not a fast success. Record
+                # it via locust's failure API so fail_ratio/--max-fail-ratio catch it instead
+                # of the parse error landing in runner.exceptions.
+                if not body:
+                    response.failure(Exception("empty response received"))
+                    return
+                try:
+                    if self.provider_formatter.parsed_options.rerank:
+                        out = self.provider_formatter.parse_output_json(orjson.loads(body))
+                        if out.prompt_tokens:
+                            prompt_tokens = out.prompt_tokens
+                        if show_response:
+                            combined_text = out.text
+                    elif show_response:
                         resp_data = orjson.loads(body)
                         server_prompt_tokens = (resp_data.get("usage") or {}).get("prompt_tokens")
                         out = self.provider_formatter.parse_output_json(resp_data)
                         combined_text = str(out.text)
                     else:
                         server_prompt_tokens = extract_prompt_tokens(body)
+                except Exception as e:
+                    logger.error(f"Failed to parse response body with error {repr(e)}")
+                    response.failure(e)
+                    return
+
+                # Only count a first token once the body has parsed successfully, so an empty
+                # or malformed response is reported as a failure rather than a zero-latency success.
+                now = time.perf_counter()
+                t_first_token = now
+                if self.provider_formatter.parsed_options.embeddings:
                     if server_prompt_tokens:
                         prompt_tokens = server_prompt_tokens
                     add_custom_metric("latency_per_embedding", (now - t_start) / batch_size * 1000)

--- a/llm_bench/test_embeddings_response.py
+++ b/llm_bench/test_embeddings_response.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import orjson
+import pytest
+
+from load_test import extract_prompt_tokens
+
+
+def _embeddings_body(batch_size: int, dims: int = 4096, prompt_tokens: int = 21132) -> bytes:
+    return orjson.dumps(
+        {
+            "object": "list",
+            "data": [
+                {"object": "embedding", "index": i, "embedding": [0.0123456789] * dims} for i in range(batch_size)
+            ],
+            "model": "accounts/fireworks/models/some-embed-model",
+            "usage": {"prompt_tokens": prompt_tokens, "total_tokens": prompt_tokens},
+        }
+    )
+
+
+@pytest.mark.parametrize("batch_size", [1, 8, 64])
+def test_extract_prompt_tokens_matches_full_parse(batch_size: int) -> None:
+    body = _embeddings_body(batch_size)
+
+    assert extract_prompt_tokens(body) == orjson.loads(body)["usage"]["prompt_tokens"]
+
+
+def test_extract_prompt_tokens_falls_back_when_field_absent() -> None:
+    body = orjson.dumps({"object": "list", "data": [], "usage": {"total_tokens": 7}})
+
+    assert extract_prompt_tokens(body) is None
+
+
+def test_extract_prompt_tokens_survives_malformed_body() -> None:
+    assert extract_prompt_tokens(b"not json at all") is None
+
+
+def test_extract_prompt_tokens_tolerates_whitespace() -> None:
+    assert extract_prompt_tokens(b'{"usage": {"prompt_tokens" :  4096 }}') == 4096


### PR DESCRIPTION
## Problem

Embeddings and rerank load tests have been reporting endpoint latency that is almost entirely client-side CPU time.

Both are single-response JSON APIs, but their responses were drained through `response.iter_lines(delimiter=b"\n\n")`. A JSON document never contains `\n\n`, so `requests`' `iter_lines` never finds a delimiter: it accumulates the whole body in `pending` and, for every 512-byte chunk (`ITER_CHUNK_SIZE`), does `pending + chunk` and then `chunk.split(delimiter)` across the entire accumulated buffer. That is quadratic in body size.

Embeddings bodies are big — a batch of 50 inputs at 4096 dims is ~2.7 MB — so the scan costs seconds per response. And because it's a tight C-level scan over Python bytes with no I/O, it never yields to gevent, so it serializes across greenlets. The load generator, not the endpoint, becomes the bottleneck.

Measured cost of the old read path by batch size:

| batch | body | old read+parse | new |
|---|---|---|---|
| 8 | 0.43 MB | 100 ms | 0.12 ms |
| 25 | 1.33 MB | 960 ms | 0.43 ms |
| 50 | 2.66 MB | 3,852 ms | 0.63 ms |
| 64 | 3.41 MB | 5,814 ms | 0.84 ms |

## Fix

Read the body once for these two endpoints and leave the chunk loop to the streaming paths. When `--show-response` is off, skip decoding the float arrays altogether — `usage.prompt_tokens` is scanned out of the raw bytes, with a fallback to a real parse if the scan misses.

## Verification

Stub `/v1/embeddings` returning a 2.7 MB body, `--embeddings-batch-size 50`, 8 users, 30 s:

| | requests completed | `total_latency` p50 |
|---|---|---|
| before | 14 | 18,000 ms |
| after | **8,366** | **22 ms** |

The stub's `fireworks-server-processing-time` was a constant 120 ms in both runs, so the entire difference was client-side. Unit tests added for the `usage` extraction (exact-match against a full parse, absent field, malformed body, whitespace).

## Also

Surfaces `response_bytes` and `server_side_total_latency` in the embeddings and rerank summary rows, so a client-side ceiling shows up in the results rather than being read as server latency.

## Impact

Any embeddings or rerank benchmark run to date understates endpoint throughput and overstates latency, increasingly so with larger batch sizes and embedding dimensions. Streaming and completions paths are untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only client path change with tests; streaming/completions untouched. Regex scan for prompt_tokens has a safe orjson fallback.
> 
> **Overview**
> Fixes **embeddings and rerank** load tests that were bottlenecked on the Locust client, not the API. Those endpoints return a single JSON body, but the client drained them via `iter_lines(delimiter=b"\n\n")`, causing quadratic buffering/scans on multi‑MB responses and blocking gevent greenlets—so reported latency and throughput were mostly client CPU.
> 
> **Rerank/embeddings** now use `response.content` once and skip the line iterator; streaming/completions paths are unchanged. When `--show-response` is off for embeddings, **`extract_prompt_tokens`** scans raw bytes for `usage.prompt_tokens` instead of parsing huge float arrays, with JSON parse fallback. **`response_bytes`** is recorded, and summary CSV rows for embeddings/rerank add **`response_bytes`** and **`server_side_total_latency`** (with percentiles where applicable). Unit tests cover the token extractor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3d39fafa65dbdf48846e7b77543009334caeefb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->