### PR TITLE
fix(llm-bench): retry generation warmup transport errors

### DIFF
--- a/llm_bench/gen_load_test.py
+++ b/llm_bench/gen_load_test.py
@@ -621,16 +621,32 @@ def _warmup_seq_len(
             retries,
         )
         request_users: list[Optional[str]] = list(users) if users is not None else [None] * concurrency
-        if concurrency == 1:
-            responses = [_single(0, request_users[0])]
-        else:
-            with ThreadPoolExecutor(max_workers=concurrency) as pool:
-                futures = [pool.submit(_single, i, u) for i, u in enumerate(request_users)]
-                responses = [f.result() for f in as_completed(futures)]
+        try:
+            if concurrency == 1:
+                responses = [_single(0, request_users[0])]
+            else:
+                with ThreadPoolExecutor(max_workers=concurrency) as pool:
+                    futures = [pool.submit(_single, i, u) for i, u in enumerate(request_users)]
+                    responses = [f.result() for f in as_completed(futures)]
+        except requests.exceptions.RequestException as error:
+            if attempt < retries:
+                logger.warning(
+                    "Warmup seq_len=%d failed (attempt %d/%d): %s. Retrying in %.0fs ...",
+                    seq_len,
+                    attempt,
+                    retries,
+                    error,
+                    retry_delay,
+                )
+                time.sleep(retry_delay)
+                continue
+            raise
 
         bad = next((r for r in responses if r.status_code != 200), None)
         if bad is None:
             return
+        if 400 <= bad.status_code < 500 and bad.status_code not in (408, 429):
+            raise RuntimeError(f"Warmup seq_len={seq_len} failed HTTP {bad.status_code}: {bad.text[:500]}")
         if attempt < retries:
             logger.warning(
                 "Warmup seq_len=%d failed HTTP %d: %s. Retrying in %.0fs ...",

--- a/llm_bench/test_gen_load_test.py
+++ b/llm_bench/test_gen_load_test.py
@@ -1,0 +1,85 @@
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+import gen_load_test
+
+
+def _response(status_code: int = 200, text: str = "") -> Mock:
+    return Mock(status_code=status_code, text=text)
+
+
+def _warmup(*, concurrency: int = 1, retries: int = 3) -> None:
+    gen_load_test._warmup_seq_len(
+        url="https://example.test/v1/completions",
+        api_key=None,
+        model="model",
+        prompt_ids=[1, 2, 3],
+        seq_len=3,
+        concurrency=concurrency,
+        temperature=None,
+        retries=retries,
+        retry_delay=0,
+    )
+
+
+def test_warmup_retries_transport_exception_from_future(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    post = Mock(
+        side_effect=[
+            requests.exceptions.SSLError("connection closed"),
+            _response(),
+            _response(),
+            _response(),
+        ]
+    )
+    sleep = Mock()
+    monkeypatch.setattr(gen_load_test, "post_completion", post)
+    monkeypatch.setattr(gen_load_test.time, "sleep", sleep)
+
+    _warmup(concurrency=2)
+
+    assert post.call_count == 4
+    sleep.assert_called_once_with(0)
+
+
+def test_warmup_transport_retry_exhaustion_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    post = Mock(side_effect=requests.exceptions.SSLError("connection closed"))
+    sleep = Mock()
+    monkeypatch.setattr(gen_load_test, "post_completion", post)
+    monkeypatch.setattr(gen_load_test.time, "sleep", sleep)
+
+    with pytest.raises(requests.exceptions.SSLError, match="connection closed"):
+        _warmup(concurrency=2)
+
+    assert post.call_count == 6
+    assert sleep.call_count == 2
+
+
+def test_successful_warmup_is_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    post = Mock(return_value=_response())
+    sleep = Mock()
+    monkeypatch.setattr(gen_load_test, "post_completion", post)
+    monkeypatch.setattr(gen_load_test.time, "sleep", sleep)
+
+    _warmup()
+
+    post.assert_called_once()
+    sleep.assert_not_called()
+
+
+def test_warmup_does_not_retry_client_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    post = Mock(return_value=_response(status_code=400, text="invalid prompt"))
+    sleep = Mock()
+    monkeypatch.setattr(gen_load_test, "post_completion", post)
+    monkeypatch.setattr(gen_load_test.time, "sleep", sleep)
+
+    with pytest.raises(RuntimeError, match="failed HTTP 400: invalid prompt"):
+        _warmup()
+
+    post.assert_called_once()
+    sleep.assert_not_called()


### PR DESCRIPTION
## Summary

- Retry transient `requests.exceptions.RequestException` failures raised by generation warmup futures through the existing bounded warmup attempt loop.
- Keep the established attempt count, delay, and warning format; deterministic client errors fail immediately while HTTP 408/429 remain retryable.
- Add focused coverage for SSL recovery, exhaustion, unchanged success behavior, and non-retryable HTTP failures.

## Failure mode

Normal measured requests already retry exceptions around `_run_pair_*`, but `_warmup_seq_len` resolved `future.result()` without handling transport exceptions, so a transient TLS/network close escaped immediately and failed the run. This hardens benchmark CI against that transient failure; it does not claim to fix the underlying network close.

## Code overview

```mermaid
flowchart TD
    A[Issue warmup request set] --> B{Transport exception?}
    B -- yes, attempts remain --> C[Log and back off]
    C --> A
    B -- yes, exhausted --> D[Re-raise transport error]
    B -- no --> E{HTTP result}
    E -- success --> F[Continue benchmark]
    E -- deterministic 4xx --> G[Fail immediately]
    E -- retryable failure --> C
```

## Testing

- `python -m pytest -q llm_bench` — 31 passed
- `python -m black --check llm_bench/test_gen_load_test.py`
- `python -m ruff check llm_bench/test_gen_load_test.py`
- `python -m compileall -q llm_bench/gen_load_test.py llm_bench/test_gen_load_test.py`
- `git diff --check`

## Reviewer ask

Correctness is covered by unit tests; no manual repro is needed. Please focus on the bounded request-set retry scope, future/executor handling, and the distinction between transient transport/408/429 failures and deterministic 4xx responses. Root-causing the network close is intentionally out of scope.

## Performance evidence

- [x] Not a performance-sensitive change.

Made with [Cursor](https://cursor.com)